### PR TITLE
Ferris Wheel Slideshow

### DIFF
--- a/examples/ferrisWheelSlideshow.little
+++ b/examples/ferrisWheelSlideshow.little
@@ -1,0 +1,273 @@
+(def [slideN slideSlider] (hSlider true 20! 400! 20! 1! 13! 'Slide ' 1))
+(def [timeInSlide timeInSlideSlider] (hSlider false 20! 400! 40! 0.0! 1.0! 'Time in Slide ' 0.0))
+
+(def rimColor [0 0 0 1])
+(def beamWidth 1)
+(def [centerX centerY] [300 300])
+(def [smallRadius largeRadius] [50 150])
+(def spokeEndSize 3)
+(def hubRadius 12)
+(def [carHighlightColor carColor] [[251 191 141 1] [191 191 191 1]])
+(def [carWidth carHeight] [20 20])
+(def spokeDuplicationOffset 12)
+(def carDuplicationOffset (+ carWidth 12))
+(def carDiagonalDuplicationOffset 14)
+(def rotationAngle (* twoPi 0.03))
+
+(def spoke (\(centerX centerY rimX rimY)
+  [
+    (line 'black' 1 centerX centerY rimX rimY)
+    (circle 'black' rimX rimY spokeEndSize)
+  ]
+))
+
+(def diameterSpoke (\(x1 y1 x2 y2)
+  [
+    (line 'black' 1 x1 y1 x2 y2)
+    (circle 'black' x1 y1 spokeEndSize)
+    (circle 'black' x2 y2 spokeEndSize)
+  ]
+))
+
+(def car_ (\(fill x y w h)
+  ; Manual, so we can add stroke.
+  [
+    'rect'
+    [ ['x' (- x (/ w 2))] ['y' (- y (/ h 2))] ['width' w] ['height' h] ['fill' fill] ['stroke' 'black'] ]
+    []
+  ]
+))
+
+(def hub_ (\(fill x y r)
+  ; Manual, so we can add stroke.
+  [
+    'circle'
+    [ ['cx' x] ['cy' y] ['r' r] ['fill' fill] ['stroke' 'black'] ]
+    []
+  ]
+))
+
+(def rimAttachmentPoints (\(spokeCount radius angle centerX centerY)
+  (let angles (map (\i (- (+ (* (/ i spokeCount) twoPi) angle) halfPi)) (range 0 (- spokeCount 1)))
+    (map (\angle [(+ centerX (* (cos angle) radius)) (+ centerY (* (sin angle) radius))]) angles)
+  )
+))
+
+(def carsAndHub (\(spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+  (let hub [(hub_ carColor centerX centerY hubRadius)]
+  (let [[highlightedCarX highlightedCarY]|otherRimAttachmentPoints] (rimAttachmentPoints spokeCount radius angle centerX centerY)
+  (let highlightedCar [(car_ carHighlightColor highlightedCarX highlightedCarY carWidth carHeight)]
+  (let otherCars (map (\[x y] (car_ carColor x y carWidth carHeight)) otherRimAttachmentPoints)
+    [hub highlightedCar otherCars]
+  ))))
+))
+
+(def rimAndSpokes (\(spokeCount radius angle centerX centerY)
+  (let rim [(ring rimColor beamWidth centerX centerY radius)]
+  (let spokes (map (\[x y] (spoke centerX centerY x y)) (rimAttachmentPoints spokeCount radius angle centerX centerY))
+    [rim (concat spokes)]
+  ))
+))
+
+(def ferrisWheel (\(spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+  (concat [
+    (carsAndHub spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+    (rimAndSpokes spokeCount radius angle centerX centerY)
+  ])
+))
+
+(def hub [(hub_ carColor centerX centerY hubRadius)])
+(def smallRim [(ring rimColor beamWidth centerX centerY smallRadius)])
+(def spoke1 (diameterSpoke centerX (+ centerY smallRadius) centerX (- centerY smallRadius)))
+(def spoke1Duplicate1 (diameterSpoke (+ centerX spokeDuplicationOffset) (+ (+ centerY smallRadius) spokeDuplicationOffset) (+ centerX spokeDuplicationOffset) (+ (- centerY smallRadius) spokeDuplicationOffset)))
+(def spoke1Duplicate2 (diameterSpoke (+ centerX (mult 2 spokeDuplicationOffset)) (+ (+ centerY smallRadius) (mult 2 spokeDuplicationOffset)) (+ centerX (mult 2 spokeDuplicationOffset)) (+ (- centerY smallRadius) (mult 2 spokeDuplicationOffset))))
+(def spoke1Duplicate1HalfMoved (diameterSpoke (+ centerX spokeDuplicationOffset) (+ (+ centerY smallRadius) spokeDuplicationOffset) (- centerX smallRadius) centerY))
+(def spoke2 (diameterSpoke (+ centerX smallRadius) centerY (- centerX smallRadius) centerY))
+
+(def car (\(x y)
+  [(car_ carColor x y carWidth carHeight)]
+))
+
+(def highlightedCar (\(x y)
+  [(car_ carHighlightColor x y carWidth carHeight)]
+))
+
+(def car1 (highlightedCar centerX (- centerY smallRadius)))
+(def car1Duplicates (map (\n (car (+ centerX (* n carDuplicationOffset)) (- centerY smallRadius))) (range 1 3)))
+
+(def ferrisSmall4
+  (ferrisWheel
+    4 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def car2Duplicates (map (\n (car (+ smallRadius (+ centerX (* n carDiagonalDuplicationOffset))) (+ centerY (* n carDiagonalDuplicationOffset)))) (range 1 3)))
+(def ferrisSmall4CarsAndHub
+  (carsAndHub
+    4 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8CarsAndHub
+  (carsAndHub
+    8 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8RimAndSpokes
+  (rimAndSpokes
+    8 ; number of spokes
+    smallRadius
+    0 ; angle
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8
+  (concat [ferrisSmall8CarsAndHub ferrisSmall8RimAndSpokes])
+)
+(def ferrisLarge8RimAndSpokesOffset
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    (+ centerX (- largeRadius smallRadius))
+    (- centerY (- largeRadius smallRadius))
+  )
+)
+(def ferrisLarge8RimAndSpokes
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8
+  (ferrisWheel
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8BadlyRotated
+  [(rotate
+    ['g' [] (concat ferrisLarge8)]
+    (/ (* rotationAngle 360) twoPi)
+    centerX
+    centerY
+  )]
+)
+
+(def [car7X car7Y] (hd (reverse (rimAttachmentPoints 8 largeRadius rotationAngle centerX centerY))))
+(def car7 (car car7X car7Y))
+(def car7Duplicates (map (\n (car (+ car7X (* n carDiagonalDuplicationOffset)) (+ car7Y (* n carDiagonalDuplicationOffset)))) (range 1 7)))
+
+(def ferrisLarge8RimAndSpokesRotated
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    rotationAngle
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8Rotated
+  (ferrisWheel
+    8 ; number of spokes
+    largeRadius
+    (+ rotationAngle (* twoPi timeInSlide))
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+
+(def appearInOrder (\shapeGroups
+  (let appearanceTimeAndShapeGroups (map2 (\(i shapeGroup) [(/ i (len shapeGroups)) shapeGroup]) (range 0 (- (len shapeGroups) 1)) shapeGroups)
+    (foldr
+      (\([t shapeGroup] visible)
+        (if (ge timeInSlide t)
+          (let opacity (/ (- timeInSlide t) (/ 1 (len shapeGroups)))
+          (let faded [['g' [['opacity' opacity]] shapeGroup]]
+            [faded | visible]
+          ))
+          visible
+        )
+      )
+      []
+      appearanceTimeAndShapeGroups
+    )
+  )
+))
+
+(def elements
+  (if (= slideN 1)
+    (appearInOrder [smallRim spoke1 spoke1Duplicate1])
+    (if (= slideN 2)
+      [smallRim spoke1 spoke1Duplicate1HalfMoved]
+      (if (= slideN 3)
+        (concat [ [hub car1] (appearInOrder car1Duplicates) [smallRim spoke1 spoke2] ])
+        (if (= slideN 4)
+          ferrisSmall4
+          (if (= slideN 5)
+            (concat [ ferrisSmall4 (appearInOrder (concat [[spoke1Duplicate1 spoke1Duplicate2] car2Duplicates])) ])
+            (if (= slideN 6)
+              (concat [ ferrisSmall4CarsAndHub ferrisSmall8RimAndSpokes (appearInOrder car2Duplicates) ])
+              (if (= slideN 7)
+                ferrisSmall8
+                (if (= slideN 8)
+                  (concat [ ferrisSmall8CarsAndHub ferrisLarge8RimAndSpokesOffset ])
+                  (if (= slideN 9)
+                    (concat [ ferrisSmall8CarsAndHub ferrisLarge8RimAndSpokes ])
+                    (if (= slideN 10)
+                      ferrisLarge8
+                      (if (= slideN 11)
+                        [ferrisLarge8BadlyRotated]
+                        (if (= slideN 12)
+                          (concat [ [hub car7] ferrisLarge8RimAndSpokesRotated (appearInOrder car7Duplicates) ])
+                          (if (= slideN 13)
+                            ferrisLarge8Rotated
+                            []
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+(svg (append (concat elements) (concat [slideSlider timeInSlideSlider])))

--- a/src/ExamplesGenerated.elm
+++ b/src/ExamplesGenerated.elm
@@ -2047,7 +2047,7 @@ examples =
   , makeExample "Cover Logo" cover
   , makeExample "POP-PL Logo" poppl
   , makeExample "Matrix Transformations" matrices
-  , makeExample "Cult of Lambda" cultOfLambda 
+  , makeExample "Cult of Lambda" cultOfLambda
   , makeExample "Misc Shapes" miscShapes
   , makeExample "Interface Buttons" interfaceButtons
   , makeExample "Paths 1" paths1

--- a/src/ExamplesGenerated.elm
+++ b/src/ExamplesGenerated.elm
@@ -856,6 +856,282 @@ ferris =
 
 "
 
+ferrisWheelSlideshow =
+ "(def [slideN slideSlider] (hSlider true 20! 400! 20! 1! 13! 'Slide ' 1))
+(def [timeInSlide timeInSlideSlider] (hSlider false 20! 400! 40! 0.0! 1.0! 'Time in Slide ' 0.0))
+
+(def rimColor [0 0 0 1])
+(def beamWidth 1)
+(def [centerX centerY] [300 300])
+(def [smallRadius largeRadius] [50 150])
+(def spokeEndSize 3)
+(def hubRadius 12)
+(def [carHighlightColor carColor] [[251 191 141 1] [191 191 191 1]])
+(def [carWidth carHeight] [20 20])
+(def spokeDuplicationOffset 12)
+(def carDuplicationOffset (+ carWidth 12))
+(def carDiagonalDuplicationOffset 14)
+(def rotationAngle (* twoPi 0.03))
+
+(def spoke (\\(centerX centerY rimX rimY)
+  [
+    (line 'black' 1 centerX centerY rimX rimY)
+    (circle 'black' rimX rimY spokeEndSize)
+  ]
+))
+
+(def diameterSpoke (\\(x1 y1 x2 y2)
+  [
+    (line 'black' 1 x1 y1 x2 y2)
+    (circle 'black' x1 y1 spokeEndSize)
+    (circle 'black' x2 y2 spokeEndSize)
+  ]
+))
+
+(def car_ (\\(fill x y w h)
+  ; Manual, so we can add stroke.
+  [
+    'rect'
+    [ ['x' (- x (/ w 2))] ['y' (- y (/ h 2))] ['width' w] ['height' h] ['fill' fill] ['stroke' 'black'] ]
+    []
+  ]
+))
+
+(def hub_ (\\(fill x y r)
+  ; Manual, so we can add stroke.
+  [
+    'circle'
+    [ ['cx' x] ['cy' y] ['r' r] ['fill' fill] ['stroke' 'black'] ]
+    []
+  ]
+))
+
+(def rimAttachmentPoints (\\(spokeCount radius angle centerX centerY)
+  (let angles (map (\\i (- (+ (* (/ i spokeCount) twoPi) angle) halfPi)) (range 0 (- spokeCount 1)))
+    (map (\\angle [(+ centerX (* (cos angle) radius)) (+ centerY (* (sin angle) radius))]) angles)
+  )
+))
+
+(def carsAndHub (\\(spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+  (let hub [(hub_ carColor centerX centerY hubRadius)]
+  (let [[highlightedCarX highlightedCarY]|otherRimAttachmentPoints] (rimAttachmentPoints spokeCount radius angle centerX centerY)
+  (let highlightedCar [(car_ carHighlightColor highlightedCarX highlightedCarY carWidth carHeight)]
+  (let otherCars (map (\\[x y] (car_ carColor x y carWidth carHeight)) otherRimAttachmentPoints)
+    [hub highlightedCar otherCars]
+  ))))
+))
+
+(def rimAndSpokes (\\(spokeCount radius angle centerX centerY)
+  (let rim [(ring rimColor beamWidth centerX centerY radius)]
+  (let spokes (map (\\[x y] (spoke centerX centerY x y)) (rimAttachmentPoints spokeCount radius angle centerX centerY))
+    [rim (concat spokes)]
+  ))
+))
+
+(def ferrisWheel (\\(spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+  (concat [
+    (carsAndHub spokeCount radius angle carWidth carHeight hubRadius centerX centerY)
+    (rimAndSpokes spokeCount radius angle centerX centerY)
+  ])
+))
+
+(def hub [(hub_ carColor centerX centerY hubRadius)])
+(def smallRim [(ring rimColor beamWidth centerX centerY smallRadius)])
+(def spoke1 (diameterSpoke centerX (+ centerY smallRadius) centerX (- centerY smallRadius)))
+(def spoke1Duplicate1 (diameterSpoke (+ centerX spokeDuplicationOffset) (+ (+ centerY smallRadius) spokeDuplicationOffset) (+ centerX spokeDuplicationOffset) (+ (- centerY smallRadius) spokeDuplicationOffset)))
+(def spoke1Duplicate2 (diameterSpoke (+ centerX (mult 2 spokeDuplicationOffset)) (+ (+ centerY smallRadius) (mult 2 spokeDuplicationOffset)) (+ centerX (mult 2 spokeDuplicationOffset)) (+ (- centerY smallRadius) (mult 2 spokeDuplicationOffset))))
+(def spoke1Duplicate1HalfMoved (diameterSpoke (+ centerX spokeDuplicationOffset) (+ (+ centerY smallRadius) spokeDuplicationOffset) (- centerX smallRadius) centerY))
+(def spoke2 (diameterSpoke (+ centerX smallRadius) centerY (- centerX smallRadius) centerY))
+
+(def car (\\(x y)
+  [(car_ carColor x y carWidth carHeight)]
+))
+
+(def highlightedCar (\\(x y)
+  [(car_ carHighlightColor x y carWidth carHeight)]
+))
+
+(def car1 (highlightedCar centerX (- centerY smallRadius)))
+(def car1Duplicates (map (\\n (car (+ centerX (* n carDuplicationOffset)) (- centerY smallRadius))) (range 1 3)))
+
+(def ferrisSmall4
+  (ferrisWheel
+    4 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def car2Duplicates (map (\\n (car (+ smallRadius (+ centerX (* n carDiagonalDuplicationOffset))) (+ centerY (* n carDiagonalDuplicationOffset)))) (range 1 3)))
+(def ferrisSmall4CarsAndHub
+  (carsAndHub
+    4 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8CarsAndHub
+  (carsAndHub
+    8 ; number of spokes
+    smallRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8RimAndSpokes
+  (rimAndSpokes
+    8 ; number of spokes
+    smallRadius
+    0 ; angle
+    centerX
+    centerY
+  )
+)
+(def ferrisSmall8
+  (concat [ferrisSmall8CarsAndHub ferrisSmall8RimAndSpokes])
+)
+(def ferrisLarge8RimAndSpokesOffset
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    (+ centerX (- largeRadius smallRadius))
+    (- centerY (- largeRadius smallRadius))
+  )
+)
+(def ferrisLarge8RimAndSpokes
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8
+  (ferrisWheel
+    8 ; number of spokes
+    largeRadius
+    0 ; angle
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8BadlyRotated
+  [(rotate
+    ['g' [] (concat ferrisLarge8)]
+    (/ (* rotationAngle 360) twoPi)
+    centerX
+    centerY
+  )]
+)
+
+(def [car7X car7Y] (hd (reverse (rimAttachmentPoints 8 largeRadius rotationAngle centerX centerY))))
+(def car7 (car car7X car7Y))
+(def car7Duplicates (map (\\n (car (+ car7X (* n carDiagonalDuplicationOffset)) (+ car7Y (* n carDiagonalDuplicationOffset)))) (range 1 7)))
+
+(def ferrisLarge8RimAndSpokesRotated
+  (rimAndSpokes
+    8 ; number of spokes
+    largeRadius
+    rotationAngle
+    centerX
+    centerY
+  )
+)
+(def ferrisLarge8Rotated
+  (ferrisWheel
+    8 ; number of spokes
+    largeRadius
+    (+ rotationAngle (* twoPi timeInSlide))
+    carWidth
+    carHeight
+    hubRadius
+    centerX
+    centerY
+  )
+)
+
+(def appearInOrder (\\shapeGroups
+  (let appearanceTimeAndShapeGroups (map2 (\\(i shapeGroup) [(/ i (len shapeGroups)) shapeGroup]) (range 0 (- (len shapeGroups) 1)) shapeGroups)
+    (foldr
+      (\\([t shapeGroup] visible)
+        (if (ge timeInSlide t)
+          (let opacity (/ (- timeInSlide t) (/ 1 (len shapeGroups)))
+          (let faded [['g' [['opacity' opacity]] shapeGroup]]
+            [faded | visible]
+          ))
+          visible
+        )
+      )
+      []
+      appearanceTimeAndShapeGroups
+    )
+  )
+))
+
+(def elements
+  (if (= slideN 1)
+    (appearInOrder [smallRim spoke1 spoke1Duplicate1])
+    (if (= slideN 2)
+      [smallRim spoke1 spoke1Duplicate1HalfMoved]
+      (if (= slideN 3)
+        (concat [ [hub car1] (appearInOrder car1Duplicates) [smallRim spoke1 spoke2] ])
+        (if (= slideN 4)
+          ferrisSmall4
+          (if (= slideN 5)
+            (concat [ ferrisSmall4 (appearInOrder (concat [[spoke1Duplicate1 spoke1Duplicate2] car2Duplicates])) ])
+            (if (= slideN 6)
+              (concat [ ferrisSmall4CarsAndHub ferrisSmall8RimAndSpokes (appearInOrder car2Duplicates) ])
+              (if (= slideN 7)
+                ferrisSmall8
+                (if (= slideN 8)
+                  (concat [ ferrisSmall8CarsAndHub ferrisLarge8RimAndSpokesOffset ])
+                  (if (= slideN 9)
+                    (concat [ ferrisSmall8CarsAndHub ferrisLarge8RimAndSpokes ])
+                    (if (= slideN 10)
+                      ferrisLarge8
+                      (if (= slideN 11)
+                        [ferrisLarge8BadlyRotated]
+                        (if (= slideN 12)
+                          (concat [ [hub car7] ferrisLarge8RimAndSpokesRotated (appearInOrder car7Duplicates) ])
+                          (if (= slideN 13)
+                            ferrisLarge8Rotated
+                            []
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+(svg (append (concat elements) (concat [slideSlider timeInSlideSlider])))
+"
+
 pieChart1 =
  "; A Pie Chart
 ;
@@ -2035,6 +2311,7 @@ examples =
   , makeExample "Frank Lloyd Wright" flw1
   , makeExample "Frank Lloyd Wright B" flw2
   , makeExample "Ferris Wheel" ferris
+  , makeExample "Ferris Wheel Slideshow" ferrisWheelSlideshow
   , makeExample "Pie Chart" pieChart1
   , makeExample "Solar System" solarSystem
   , makeExample "Bezier Curves" bezier

--- a/src/ExamplesTemplate.elm
+++ b/src/ExamplesTemplate.elm
@@ -43,6 +43,7 @@ LITTLE_TO_ELM frenchSudan
 LITTLE_TO_ELM flw1
 LITTLE_TO_ELM flw2
 LITTLE_TO_ELM ferris
+LITTLE_TO_ELM ferrisWheelSlideshow
 LITTLE_TO_ELM pieChart1
 LITTLE_TO_ELM solarSystem
 LITTLE_TO_ELM fractalTree
@@ -100,6 +101,7 @@ examples =
   , makeExample "Frank Lloyd Wright" flw1
   , makeExample "Frank Lloyd Wright B" flw2
   , makeExample "Ferris Wheel" ferris
+  , makeExample "Ferris Wheel Slideshow" ferrisWheelSlideshow
   , makeExample "Pie Chart" pieChart1
   , makeExample "Solar System" solarSystem
   , makeExample "Bezier Curves" bezier

--- a/src/ExamplesTemplate.elm
+++ b/src/ExamplesTemplate.elm
@@ -112,7 +112,7 @@ examples =
   , makeExample "Cover Logo" cover
   , makeExample "POP-PL Logo" poppl
   , makeExample "Matrix Transformations" matrices
-  , makeExample "Cult of Lambda" cultOfLambda 
+  , makeExample "Cult of Lambda" cultOfLambda
   , makeExample "Misc Shapes" miscShapes
   , makeExample "Interface Buttons" interfaceButtons
   , makeExample "Paths 1" paths1

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -9,7 +9,7 @@ import ExamplesGenerated as Examples
 import LangUnparser exposing (unparseE)
 import OurParser2 as P
 
-import List 
+import List
 import Debug
 import String
 import Dict
@@ -41,7 +41,7 @@ type alias Model =
                              -- Just s is True, where s is previous code
   , caption : Maybe Caption
   , localSaves : List String
-  , fieldContents : DialogInfo 
+  , fieldContents : DialogInfo
   , startup : Bool
   , codeBoxInfo : CodeBoxInfo
   , basicCodeBox : Bool

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -16,11 +16,11 @@ import OurParser2 as P
 import VirtualDom
 
 --Core Libraries
-import List 
+import List
 import Dict
 import Set
-import String 
-import Graphics.Element as GE 
+import String
+import Graphics.Element as GE
 import Graphics.Collage as GC
 import Graphics.Input as GI
 import Graphics.Input.Field as GIF
@@ -28,8 +28,8 @@ import Text as T exposing (defaultStyle)
 import Color
 
 --Signaling Libraries
-import Mouse 
-import Window 
+import Mouse
+import Window
 import Task exposing (Task, andThen)
 
 --Storage Libraries
@@ -41,7 +41,7 @@ import InterfaceStorage exposing (taskMailbox, saveStateLocally, loadLocalState,
 import CodeBox exposing (saveRequestInfo, runRequestInfo)
 
 --Html Libraries
-import Html 
+import Html
 import Html.Attributes as Attr
 import Html.Events as Events
 import Html.Lazy
@@ -66,7 +66,7 @@ textColor = "white"
 titleStyle =
   { defaultStyle | typeface <- ["Courier", "monospace"]
                  , height <- Just 18
-                 , bold <- False 
+                 , bold <- False
                  , color <- Color.white}
 
 -- Creates an Html button with the text properly offset
@@ -511,7 +511,7 @@ codebox_ w h event s readOnly =
              , ("border", params.mainSection.codebox.border)
              , ("whiteSpace", "pre")
              , ("height", "100%")
-             , ("width", "100%") 
+             , ("width", "100%")
              , ("resize", "none")
              , ("overflow", "auto")
              -- Horizontal Scrollbars in Chrome
@@ -541,7 +541,7 @@ errorBox w h errormsg =
         , ("border", params.mainSection.codebox.border)
         , ("whiteSpace", "pre")
         , ("height", "100%")
-        , ("width", "100%") 
+        , ("width", "100%")
         , ("resize", "none")
         , ("overflow", "auto")
         -- Horizontal Scrollbars in Chrome
@@ -687,12 +687,12 @@ mainSectionVertical w h model =
                 + params.mainSection.vertical.hExtra
   in
 
-  let codeSection = if model.basicCodeBox 
+  let codeSection = if model.basicCodeBox
                        then codebox wCode h model
                        else codeBox wCode h in
 
   let canvasSection = case model.errorBox of
-    Nothing -> 
+    Nothing ->
       GE.size wCanvas h <|
         GE.flow GE.down
           [ canvas wCanvas hCanvas model
@@ -735,7 +735,7 @@ mainSectionHorizontal w h model =
                        else codeBox w hCode in
 
   let canvasSection = case model.errorBox of
-    Nothing -> 
+    Nothing ->
         GE.size w (hCanvas + hZInfo) <|
           GE.flow GE.down
             [ canvas w hCanvas model
@@ -764,7 +764,7 @@ simpleButton_
    : Signal.Address a -> a -> Bool -> a -> String -> String -> String
   -> Int -> Int -> GE.Element
 simpleButton_ addy defaultMsg disabled msg value name text w h =
-  if disabled then 
+  if disabled then
       GI.customButton (Signal.message addy defaultMsg)
         (makeButton Disabled w h text)
         (makeButton Disabled w h text)
@@ -838,7 +838,7 @@ saveButton model w h =
        simpleEventButton_ disabled (InterfaceModel.WaitSave model.exName) dn dn dn w h
 
 saveAsButton : Model -> Int -> Int -> GE.Element
-saveAsButton model w h = 
+saveAsButton model w h =
     let dn = "Save As"
     in simpleTaskButton (saveStateLocally model.exName True model) dn dn dn w h
 
@@ -858,16 +858,16 @@ redoButton model =
 
 dropdownExamples : Model -> Int -> Int -> GE.Element
 dropdownExamples model w h =
-  let 
+  let
     choices = case model.mode of
       AdHoc -> [(model.exName, Signal.send events.address Noop)]
       _ ->
-        let foo (name,thunk) = (name, Signal.send events.address (SelectExample name thunk)) 
+        let foo (name,thunk) = (name, Signal.send events.address (SelectExample name thunk))
             bar saveName = (saveName, loadLocalState saveName)
             blank = ("", Task.succeed ())
             localsaves = case model.localSaves of
                 [] -> []
-                l  -> 
+                l  ->
                   List.concat
                     [ [ ("Local Saves:", Task.succeed ())
                       , blank
@@ -885,24 +885,24 @@ dropdownExamples model w h =
               , ("*Clear Local Saves*", clearLocalSaves)
               ]
             ]
-    options = List.map (\(name,task) -> 
+    options = List.map (\(name,task) ->
         if | name == model.exName ->
               Html.option
                 [ Attr.value name
                 , Attr.selected True
-                ] 
+                ]
                 [ Html.text name ]
            | otherwise ->
               Html.option
                 [ Attr.value name
-                ] 
+                ]
                 [ Html.text name ]) choices
     findTask name choices = case choices of
         (n,t) :: rest -> if | n == name -> t
                             | otherwise -> findTask name rest
         [] -> Debug.crash "Dropdown example does not have associated task"
-  in Html.toElement 120 24 <| Html.select 
-        [ Attr.style 
+  in Html.toElement 120 24 <| Html.select
+        [ Attr.style
           [ ("pointer-events", "auto")
           , ("border", "0 solid")
           , ("display", "block")
@@ -910,8 +910,8 @@ dropdownExamples model w h =
           , ("height", "24px")
           , ("font-family", "sans-serif")
           , ("font-size", "1em")
-          ] 
-        , Events.on "change" Events.targetValue 
+          ]
+        , Events.on "change" Events.targetValue
                 (\selected -> Signal.message taskMailbox.address <|
                                 findTask selected choices)
         ] options
@@ -921,7 +921,7 @@ modeButton model =
   then simpleEventButton_ True Noop "SwitchMode" "SwitchMode" "[Mode] Ad Hoc"
   else simpleEventButton_ False (SwitchMode AdHoc) "SwitchMode" "SwitchMode" "[Mode] Live"
 
-orientationButton w h model = 
+orientationButton w h model =
     let text = "[Orientation] " ++ toString model.orient
     in
       simpleButton SwitchOrient text text text w h
@@ -933,7 +933,7 @@ basicBoxButton w h model =
               Nothing -> ("[Code Box] Fancy", ToggleBasicCodeBox)
               Just _  -> ("[Code Box] Fancy", WaitCodeBox)
     in
-       simpleButton 
+       simpleButton
          evt
          text text text w h
 
@@ -990,18 +990,18 @@ turnOffCaptionAndHighlights =
 -- TODO clean this up, is needlessly bulky
 saveElement : Model -> Int -> Int -> GE.Element
 saveElement model w h = case model.mode of
-  SaveDialog x -> 
+  SaveDialog x ->
       -- Note that dimBox must not be a parent of the pickBox, as
       -- opacity of a parent clobbers that of all its children
       let dimBox = GE.color Color.black
                       <| GE.opacity 0.5
                       <| GE.spacer w h
-          pickBox = GE.container w h GE.middle  
+          pickBox = GE.container w h GE.middle
                       <| GE.color interfaceColor
                       <| GE.container 400 200 GE.middle
                       <| GE.flow GE.down
                            [ GE.flow GE.right
-                              [ GE.spacer 42 18 
+                              [ GE.spacer 42 18
                               , GE.centered <|
                                   T.style titleStyle
                                   (T.fromString "Save Work to Browser")
@@ -1011,7 +1011,7 @@ saveElement model w h = case model.mode of
                               [ Html.toElement 200 40
                                   <| Html.input
                                       [ Attr.type' "text"
-                                      , Attr.style 
+                                      , Attr.style
                                           [ ("height", "32px")
                                           , ("width", "192px")
                                           , ("padding", "4px")
@@ -1028,7 +1028,7 @@ saveElement model w h = case model.mode of
                                             <| UpdateFieldContents
                                                 { value = cont
                                                 , hint =
-                                                    model.fieldContents.hint 
+                                                    model.fieldContents.hint
                                                 }
                                           )
                                       ]
@@ -1043,18 +1043,18 @@ saveElement model w h = case model.mode of
                               ]
                            , GE.spacer 160 10
                            , GE.flow GE.right
-                              [ GE.spacer 47 50 
+                              [ GE.spacer 47 50
                               , GE.centered <|
                                   T.height 12 <|
                                   T.color Color.white <|
-                                  (T.fromString <| 
+                                  (T.fromString <|
                                   "Note: This will overwrite saves with\n"
                                   ++ "the same name. You must choose a\n"
                                   ++ "name different than a built-in example.")
                               ]
                            , GE.spacer 160 10
                            , GE.flow GE.right
-                               [ GE.spacer 112 30 
+                               [ GE.spacer 112 30
                                , simpleButton
                                   (RemoveDialog False "")
                                   "Cancel" "Cancel" "Cancel"
@@ -1062,8 +1062,8 @@ saveElement model w h = case model.mode of
                                ]
                            ]
       in GE.flow GE.outward [ dimBox, pickBox ]
-  _ -> GE.empty 
-    
+  _ -> GE.empty
+
 
 view : (Int, Int) -> Model -> GE.Element
 view (w,h) model =
@@ -1078,7 +1078,7 @@ view (w,h) model =
 
   let topSection =
     let
-      title = (\e -> GE.container (GE.widthOf e) hTop GE.middle e) <| 
+      title = (\e -> GE.container (GE.widthOf e) hTop GE.middle e) <|
                 GE.leftAligned <| T.style titleStyle (T.fromString strTitle)
 
       wLogo = params.topSection.wLogo
@@ -1136,7 +1136,7 @@ view (w,h) model =
         Signal.message taskMailbox.address <|
           -- Insert more tasks to run at startup here
           getLocalSaves `andThen` \_ ->
-        
+
           ---
           Signal.send
             events.address


### PR DESCRIPTION
This PR adds a "Ferris Wheel Slideshow" example.

Slide number is controller with a slider.

For the slides with animation, the animation time is controlled with a
second slider.

A few slides have element fade-in animations. The animation on the last
slide spins the ferris wheel without rotating the cars.

![ferris_wheel_slideshow](https://cloud.githubusercontent.com/assets/506950/10285656/782f0a52-6b4f-11e5-8bd6-424e4148a6c9.gif)
