### PR TITLE
Rudimentary Dig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ img/light_logo.svg~
 int-trees/
 src/Native/PickOption.js
 src/repl-temp-000.elm
+tests/build

--- a/README.md
+++ b/README.md
@@ -233,6 +233,31 @@ To add a new example to the dropdown menu:
 
 4. Launch Sketch-n-Sketch.
 
+## Running Tests
+
+If you hack on Sketch-n-Sketch, there are some tests to run. Writing more tests is, of course, encouraged.
+
+Run once:
+
+```
+$ ./tests/test.sh
+```
+
+Run when files change (requires [fswatch](https://emcrisostomo.github.io/fswatch/)):
+
+```
+$ ./watchtest
+```
+
+To write a new test, make a function of type `() -> String` named `somethingTest` in a `tests/myTests.elm` file. If the function returns the string `"ok"` it is considered a passing test, otherwise the returned string will be displayed as a failure message.
+
+You can also return a list of test functions, `() -> List (() -> String)`, and each test will be run individually.
+
+See [existing tests](https://github.com/ravichugh/sketch-n-sketch/tree/master/tests) for examples.
+
+### Adding/Removing Elm Packages
+
+If you add or remove a package from the project, the package list for the tests needs to be updated as well. Simply run `node tests/refresh_elm-packages.js` to copy over the main `elm-packages.json` into the tests directory.
 
 [Prelude]: https://github.com/ravichugh/sketch-n-sketch/blob/master/examples/prelude.little
 [ProjectPage]: http://ravichugh.github.io/sketch-n-sketch

--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ Run when files change (requires [fswatch](https://emcrisostomo.github.io/fswatch
 $ ./watchtest
 ```
 
+To run only tests with a certain string in their name, set `SNS_TESTS_FILTER`:
+
+```
+$ SNS_TESTS_FILTER=unparser ./watchtest
+```
+
 To write a new test, make a function of type `() -> String` named `somethingTest` in a `tests/myTests.elm` file. If the function returns the string `"ok"` it is considered a passing test, otherwise the returned string will be displayed as a failure message.
 
 You can also return a list of test functions, `() -> List (() -> String)`, and each test will be run individually.

--- a/src/ExamplesGenerated.elm
+++ b/src/ExamplesGenerated.elm
@@ -12,7 +12,7 @@ makeExample name s =
     let (v,ws) = Eval.run e in
     {e=e, v=v, ws=ws}
   in
-  (name, thunk)
+  (name, s, thunk)
 
 scratchName = "*Scratch*"
 

--- a/src/ExamplesTemplate.elm
+++ b/src/ExamplesTemplate.elm
@@ -12,7 +12,7 @@ makeExample name s =
     let (v,ws) = Eval.run e in
     {e=e, v=v, ws=ws}
   in
-  (name, thunk)
+  (name, s, thunk)
 
 scratchName = "*Scratch*"
 

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -492,7 +492,7 @@ upstate evt old = case debugLog "Event" evt of
     RelateAttrs ->
       let (_,tree) = old.slate in
       let selectedVals = debugLog "selectedVals" <|
-        let foo (id,_,attr) acc =
+        let foo (id, attr) acc =
           case Dict.get id tree of
             Just (LangSvg.SvgNode _ attrs _) ->
               case Utils.maybeFind attr attrs of

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -655,10 +655,10 @@ upstate evt old = case debugLog "Event" evt of
       -- Debug only:
       let newSubtreeStr = debugLog "newlyWrappedCommonScope" <| unparseE newlyWrappedCommonScope in
       let newExp =
-        replaceNode deepestCommonScope newlyWrappedCommonScope old.inputExp
+        replaceExpNode deepestCommonScope newlyWrappedCommonScope old.inputExp
       in
       let unparsed = debugLog "new code" <| unparseE newExp in
-      -- Reparse to reset eid's etc...
+      -- Reparse to reset eids, locs, etc...
       let newExp =
         case parseE unparsed of
           Ok reparsed -> reparsed

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -286,9 +286,9 @@ nodeIdAndAttrNameToVal (nodeId, attrName) tree =
     Just (LangSvg.SvgNode _ attrs _) ->
       case Utils.maybeFind attrName attrs of
         Just aval -> Just (LangSvg.valOfAVal aval)
-        Nothing   -> Debug.crash "nodeIdAndAttrNameToVal 2"
+        Nothing   -> Debug.crash <| "nodeIdAndAttrNameToVal " ++ (toString nodeId) ++ " " ++ (toString attrName) ++ " " ++ (toString tree)
     Just (LangSvg.TextNode _) -> Nothing
-    Nothing                   -> Debug.crash "nodeIdAndAttrNameToVal 1"
+    Nothing                   -> Debug.crash <| "nodeIdAndAttrNameToVal " ++ (toString nodeId) ++ " " ++ (toString tree)
 
 pluckSelectedVals selectedAttrs slate =
   let (_, tree) = slate in

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -118,11 +118,12 @@ type alias PossibleChange = (Exp, Val, RootedIndexedTree, Code)
 -- InterfaceStorage is more succinct (Enum typeclass would be nice here...)
 type alias ShowZones = Int
 
-showZonesModes = 6
+showZonesModeCount = 6
+
+showZonesModes = [ 0 .. (showZonesModeCount - 1) ]
 
 (showZonesNone, showZonesBasic, showZonesSelect, showZonesRot, showZonesColor, showZonesDel) =
-  Utils.unwrap6
-    [ 0 .. (showZonesModes - 1) ]
+  Utils.unwrap6 showZonesModes
 
 type ToolType
   = Cursor | SelectAttrs | SelectShapes
@@ -153,7 +154,7 @@ type Event = CodeUpdate String -- TODO this doesn't help with anything
            | StartAnimation
            | Redraw
            | ToggleOutput
-           | ToggleZones
+           | SelectZonesMode Int
            | NextSlide
            | PreviousSlide
            | NextMovie

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -235,8 +235,8 @@ codeToShow model =
 sampleModel : Model
 sampleModel =
   let
-    (name,f) = Utils.head_ Examples.list
-    {e,v,ws} = f ()
+    (name,_,f) = Utils.head_ Examples.list
+    {e,v,ws}   = f ()
   in
   let (slideCount, movieCount, movieDuration, movieContinue, indexedTree) = LangSvg.fetchEverything 1 1 0.0 v in
     { scratchCode   = Examples.scratch

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -140,7 +140,7 @@ type Event = CodeUpdate String -- TODO this doesn't help with anything
            | MouseClick (Int, Int) -- used to add points to a new polygon
            | MouseUp
            | MousePos (Int, Int)
-           | TickDelta Float -- 30fps time tick, Float is time since last tick
+           | TickDelta Float -- 60fps time tick, Float is time since last tick
            | Sync
            | PreviewCode (Maybe Code)
            | SelectOption PossibleChange

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -64,7 +64,7 @@ type alias Model =
   , errorBox : Maybe String
   , genSymCount : Int
   , toolType : ToolType
-  , selectedAttrs : Set.Set (NodeId, ShapeKind, String)
+  , selectedAttrs : Set.Set (NodeId, String)
   }
 
 type Mode

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -146,6 +146,7 @@ type Event = CodeUpdate String -- TODO this doesn't help with anything
            | SelectOption PossibleChange
            | CancelSync
            | RelateAttrs -- not using UpdateModel, since want to define handler in Controller
+           | DigHole
            | RelateShapes
            | SwitchMode Mode
            | SelectExample String (() -> {e:Exp, v:Val, ws:Widgets})

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -6,7 +6,7 @@ import Sync
 import Utils
 import LangSvg exposing (RootedIndexedTree, NodeId, ShapeKind, Zone)
 import ExamplesGenerated as Examples
-import LangUnparser exposing (unparseE)
+import LangUnparser exposing (unparse)
 import OurParser2 as P
 
 import List
@@ -241,7 +241,7 @@ sampleModel =
   let (slideCount, movieCount, movieDuration, movieContinue, indexedTree) = LangSvg.fetchEverything 1 1 0.0 v in
     { scratchCode   = Examples.scratch
     , exName        = name
-    , code          = unparseE e
+    , code          = unparse e
     , previewCode   = Nothing
     , history       = ([], [])
     , inputExp      = e

--- a/src/InterfaceStorage.elm
+++ b/src/InterfaceStorage.elm
@@ -32,6 +32,7 @@ import ExamplesGenerated as Examples
 import LangSvg exposing (emptyTree)
 
 import Config
+import Utils
 
 -- So we can crash appropriately
 import Debug
@@ -44,7 +45,7 @@ taskMailbox : Mailbox (Task String ())
 taskMailbox = mailbox (succeed ())
 
 -- Type for the partial object that we store in localStorage
-type alias PartialObject = 
+type alias PartialObject =
     { code        : String
     , orient      : Orientation
     , showZones   : InterfaceModel.ShowZones -- Int
@@ -63,7 +64,7 @@ modelToValue : Model -> Encode.Value
 modelToValue model =
     Encode.object <|
       [ ("code", Encode.string model.code)
-      , ("orient", Encode.string 
+      , ("orient", Encode.string
             (case model.orient of
                 InterfaceModel.Vertical -> "Vertical"
                 InterfaceModel.Horizontal -> "Horizontal"
@@ -79,7 +80,7 @@ strToModel : Decoder Model
 strToModel =
     let partialObjectDecoder = object5 PartialObject
             ("code" := string)
-            ("orient" := customDecoder string 
+            ("orient" := customDecoder string
                 (\v -> case v of
                     "Vertical" -> Ok InterfaceModel.Vertical
                     "Horizontal" -> Ok InterfaceModel.Horizontal
@@ -90,7 +91,7 @@ strToModel =
             ("midOffsetX"  := int)
             ("midOffsetY"  := int)
     in customDecoder partialObjectDecoder
-        (\partial -> 
+        (\partial ->
             Ok { sampleModel | code = partial.code
                              , orient = partial.orient
                              , showZones = partial.showZones
@@ -106,9 +107,9 @@ strToModel =
 -- Note that this is passed through as an Event and not an UpdateModel for the
 -- purposes of appropriately triggering rerendering in CodeBox.
 saveStateLocally : String -> Bool -> Model -> Task String ()
-saveStateLocally saveName saveAs model = 
+saveStateLocally saveName saveAs model =
     if saveAs
-      then send events.address InterfaceModel.InstallSaveState 
+      then send events.address InterfaceModel.InstallSaveState
       else send events.address (InterfaceModel.WaitSave saveName)
 
 -- Commits a save to the Local Storage
@@ -118,13 +119,13 @@ commitLocalSave saveName model = setItem saveName <| modelToValue model
 
 -- Changes state to SaveDialog
 installSaveState : Model -> Model
-installSaveState oldModel = 
+installSaveState oldModel =
     { oldModel | mode = InterfaceModel.SaveDialog oldModel.mode}
 
 -- Task to validate save field input
 checkAndSave : String -> Model -> Task String ()
 checkAndSave saveName model =
-  if List.all ((/=) saveName << fst) Examples.list
+  if List.all ((/=) saveName << Utils.fst3) Examples.list
         && saveName /= ""
         && saveName /= "__ErrorSave"
         && not (all (\c -> c == ' ' || c == '\t') saveName) then
@@ -137,14 +138,14 @@ checkAndSave saveName model =
 removeDialog : Bool -> String -> Model -> Model
 removeDialog makeSave saveName oldModel = case oldModel.mode of
     InterfaceModel.SaveDialog oldmode -> case makeSave of
-        True -> 
+        True ->
           if List.all ((/=) saveName) oldModel.localSaves then
-             { oldModel | mode = oldmode 
+             { oldModel | mode = oldmode
                         , exName = saveName
-                        , localSaves = saveName :: oldModel.localSaves 
+                        , localSaves = saveName :: oldModel.localSaves
              }
           else
-             { oldModel | mode = oldmode 
+             { oldModel | mode = oldmode
                         , exName = saveName }
         False -> { oldModel | mode = oldmode }
     _ -> Debug.crash "Called removeDialog when not in SaveDialog state"
@@ -159,14 +160,14 @@ invalidInput oldmodel =
 
 -- Task to load state from local browser storage
 loadLocalState : String -> Task String ()
-loadLocalState saveName = 
-    case List.filter ((==) saveName << fst) Examples.list of
-        (name, thunk) :: rest ->
+loadLocalState saveName =
+    case List.filter ((==) saveName << Utils.fst3) Examples.list of
+        (name, _, thunk) :: rest ->
             send events.address <| InterfaceModel.SelectExample saveName thunk
         _ -> getItem saveName strToModel
                 `andThen` \loadedModel ->
-                    send events.address <| 
-                        InterfaceModel.UpdateModel <| 
+                    send events.address <|
+                        InterfaceModel.UpdateModel <|
                             installLocalState saveName loadedModel
 
 -- Function to update model upon state load

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -537,8 +537,11 @@ type alias NodeIdAndTwoAttrNames = (LangSvg.NodeId, String, String)
 
 toggleSelected model nodeIdAndAttrNames =
   UpdateModel <| \model ->
+    -- If only some of the attrs were selected, we want to select all of
+    -- them, not toggle individually.
+    let deselect = List.all (flip Set.member model.selectedAttrs) nodeIdAndAttrNames in
     let updateSet nodeIdAndAttrName acc =
-      if Set.member nodeIdAndAttrName acc
+      if deselect
         then Set.remove nodeIdAndAttrName acc
         else Set.insert nodeIdAndAttrName acc
     in

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -1072,7 +1072,7 @@ widgetsToolExtras w h model =
     SelectAttrs  -> [ gap , relateAttrsButton w h ]
 -}
     Cursor       -> if model.showZones == showZonesSelect
-                    then gap :: (zoneButtons model w h) ++ [ relateAttrsButton w h ]
+                    then gap :: (zoneButtons model w h) ++ [ relateAttrsButton w h, digHoleButton w h]
                     else gap :: (zoneButtons model w h)
     SelectShapes -> [ gap , relateShapesButton w h ]
     _            -> []
@@ -1335,6 +1335,9 @@ syncButton =
 
 relateAttrsButton =
   simpleButton RelateAttrs "Relate" "Relate" "Relate Attrs"
+
+digHoleButton =
+  simpleButton DigHole "unused?" "unused?" "Dig Hole"
 
 relateShapesButton =
   simpleButton RelateShapes "Relate" "Relate" "Relate Shapes"

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -4,7 +4,7 @@ module InterfaceView2 (view, scaleColorBall
 
 --Import the little language and its parsing utilities
 import Lang exposing (..) --For access to what makes up the Vals
-import LangParser2 as Parser exposing (parseE, parseV)
+import LangParser2 as Parser exposing (parseE)
 import Sync
 import Eval
 import Utils

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -1424,7 +1424,7 @@ toolButton model tt w h =
 saveButton : Model -> Int -> Int -> GE.Element
 saveButton model w h =
     let cap = "Save" in
-    let disabled = List.any ((==) model.exName << fst) Examples.list in
+    let disabled = List.any ((==) model.exName << Utils.fst3) Examples.list in
     simpleEventButton_
       disabled (InterfaceModel.WaitSave model.exName)
       cap cap cap w h
@@ -1484,7 +1484,7 @@ dropdownExamples model w h =
     choices = case model.mode of
       AdHoc -> [(model.exName, Signal.send events.address Noop)]
       _ ->
-        let foo (name,thunk) = (name, Signal.send events.address (SelectExample name thunk))
+        let foo (name,_,thunk) = (name, Signal.send events.address (SelectExample name thunk))
             bar saveName = (saveName, loadLocalState saveName)
             blank = ("", Task.succeed ())
             localsaves = case model.localSaves of

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -1072,8 +1072,8 @@ widgetsToolExtras w h model =
     SelectAttrs  -> [ gap , relateAttrsButton w h ]
 -}
     Cursor       -> if model.showZones == showZonesSelect
-                    then [ gap , zoneButton model w h, relateAttrsButton w h ]
-                    else [ gap , zoneButton model w h  ]
+                    then gap :: (zoneButtons model w h) ++ [ relateAttrsButton w h ]
+                    else gap :: (zoneButtons model w h)
     SelectShapes -> [ gap , relateShapesButton w h ]
     _            -> []
 
@@ -1339,19 +1339,23 @@ relateAttrsButton =
 relateShapesButton =
   simpleButton RelateShapes "Relate" "Relate" "Relate Shapes"
 
-zoneButton model =
-  let cap =
-    if model.showZones == showZonesNone       then "[Zones] Hidden"
-    else if model.showZones == showZonesBasic then "[Zones] Basic"
-    else if model.showZones == showZonesSelect then "[Zones] Attrs"
-    else if model.showZones == showZonesRot   then "[Zones] Rotation"
-    else if model.showZones == showZonesColor then "[Zones] Color"
-    else if model.showZones == showZonesDel   then "[Zones] Delete"
+zoneButtons model w h =
+  let caption mode =
+    if mode == showZonesNone        then "[Zones] Hidden"
+    else if mode == showZonesBasic  then "[Zones] Basic"
+    else if mode == showZonesSelect then "[Zones] Attrs"
+    else if mode == showZonesRot    then "[Zones] Rotation"
+    else if mode == showZonesColor  then "[Zones] Color"
+    else if mode == showZonesDel    then "[Zones] Delete"
     else
-      Debug.crash "zoneButton"
+      Debug.crash "zoneButton caption"
   in
-  simpleEventButton_ False
-    ToggleZones "Toggle Zones" "Toggle Zones" cap
+  let zoneButton mode =
+    let selected = (model.showZones == mode) in
+    let btnKind = if selected then Selected else Unselected in
+      simpleButton_ events.address btnKind Noop False (SelectZonesMode mode) "Still dunno what this does" "Dunno what this is for" (caption mode) w h
+  in
+    List.map zoneButton showZonesModes
 
 {-
 shapeButton model =

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -535,11 +535,14 @@ strokeWidth             = LangSvg.attr "stroke-width" "10"
 type alias NodeIdAndAttrName     = (LangSvg.NodeId, String)
 type alias NodeIdAndTwoAttrNames = (LangSvg.NodeId, String, String)
 
-toggleSelected model nodeIdAndAttrName =
+toggleSelected model nodeIdAndAttrNames =
   UpdateModel <| \model ->
-    let set = model.selectedAttrs in
-    let updateSet = if Set.member nodeIdAndAttrName set then Set.remove else Set.insert in
-    { model | selectedAttrs = updateSet nodeIdAndAttrName set }
+    let updateSet nodeIdAndAttrName acc =
+      if Set.member nodeIdAndAttrName acc
+        then Set.remove nodeIdAndAttrName acc
+        else Set.insert nodeIdAndAttrName acc
+    in
+    { model | selectedAttrs = List.foldl updateSet model.selectedAttrs nodeIdAndAttrNames }
 
 -- TODO given need for model, remove addSelect
 zoneSelectPoint model addSelect quad x y =
@@ -559,7 +562,7 @@ zoneSelectPoint_ model (id, xAttr, yAttr) x y =
         LangSvg.attr "stroke" yColor , strokeWidth
       , LangSvg.attr "x1" (toString (x-len)) , LangSvg.attr "y1" (toString y)
       , LangSvg.attr "x2" (toString (x+len)) , LangSvg.attr "y2" (toString y)
-      , onMouseDown (toggleSelected model yNodeIdAndAttrName)
+      , onMouseDown (toggleSelected model [yNodeIdAndAttrName])
       ]
   in
   let xLine =
@@ -567,13 +570,14 @@ zoneSelectPoint_ model (id, xAttr, yAttr) x y =
         LangSvg.attr "stroke" xColor , strokeWidth
       , LangSvg.attr "y1" (toString (y-len)) , LangSvg.attr "x1" (toString x)
       , LangSvg.attr "y2" (toString (y+len)) , LangSvg.attr "x2" (toString x)
-      , onMouseDown (toggleSelected model xNodeIdAndAttrName)
+      , onMouseDown (toggleSelected model [xNodeIdAndAttrName])
       ]
   in
   let xyDot =
     svgCircle [
         LangSvg.attr "fill" "darkgray" , LangSvg.attr "r" "6"
       , LangSvg.attr "cx" (toString x) , LangSvg.attr "cy" (toString y)
+      , onMouseDown (toggleSelected model [xNodeIdAndAttrName, yNodeIdAndAttrName])
       ]
   in
   [xLine, yLine, xyDot]
@@ -593,7 +597,7 @@ zoneSelectLine_ model nodeIdAndAttrName (x1,y1) (x2,y2) =
         LangSvg.attr "stroke" color , strokeWidth
       , LangSvg.attr "x1" (toString x1) , LangSvg.attr "y1" (toString y1)
       , LangSvg.attr "x2" (toString x2) , LangSvg.attr "y2" (toString y2)
-      , onMouseDown (toggleSelected model nodeIdAndAttrName)
+      , onMouseDown (toggleSelected model [nodeIdAndAttrName])
       ]
   in
   [line]

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -357,27 +357,6 @@ mapExpViaExp__ f e =
   let f' exp = wrap (f exp.val.e__) in
   mapExp f' e
 
-  -- let foo = mapExpViaExp__ f in
-  -- let g e__ = P.WithInfo (Exp_ (f e__) e.val.eid) e.start e.end in
-  -- case e.val.e__ of
-  --   EConst _ _ _   -> g e.val.e__
-  --   EBase _        -> g e.val.e__
-  --   EVar _         -> g e.val.e__
-  --   EFun ps e'     -> g (EFun ps (foo e'))
-  --   EApp e1 es     -> g (EApp (foo e1) (List.map foo es))
-  --   EOp op es      -> g (EOp op (List.map foo es))
-  --   EList es m     -> g (EList (List.map foo es) (Utils.mapMaybe foo m))
-  --   EIndList rs    -> let foo r_ = case r_ of
-  --                       Interval e1 e2 -> Interval (mapExpViaExp__ f e1) (mapExpViaExp__ f e2)
-  --                       Point e1       -> Point (mapExpViaExp__ f e1)
-  --                     in
-  --                     g (EIndList (List.map (mapValField foo) rs))
-  --   EIf e1 e2 e3   -> g (EIf (foo e1) (foo e2) (foo e3))
-  --   ECase e1 l     -> g (ECase (foo e1) (List.map (mapValField (\(p,ei) -> (p, foo ei))) l))
-  --   EComment s e1  -> g (EComment s (foo e1))
-  --   EOption s1 s2 e1 -> g (EOption s1 s2 (foo e1))
-  --   ELet k b p e1 e2 -> g (ELet k b p (foo e1) (foo e2))
-
 mapVal : (Val -> Val) -> Val -> Val
 mapVal f v = case v.v_ of
   VList vs         -> f { v | v_ = VList (List.map (mapVal f) vs) }

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -20,7 +20,6 @@ type alias Num = Float
 
 type alias Frozen = String -- b/c comparable
 (frozen, unann, thawed, assignOnlyOnce) = ("!", "", "?", "~")
-  -- TODO may want a "slider" annotation so that "!" doesn't get printed
 
 type alias LocSet = Set.Set Loc
 

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -31,10 +31,10 @@ type alias Range  = P.WithInfo Range_
 
 -- TODO add constant literals to patterns, and match 'svg'
 type Pat_
-  = PVar Ident WidgetDecl
-  | PConst Num
-  | PBase BaseVal
-  | PList (List Pat) (Maybe Pat)
+  = PVar WS Ident WidgetDecl
+  | PConst WS Num
+  | PBase WS BaseVal
+  | PList WS (List Pat) WS (Maybe Pat) WS
 
 type Op_
   -- nullary ops
@@ -56,19 +56,19 @@ type alias EId  = Int
 type alias Exp_ = { e__ : Exp__, eid : EId }
 
 type Exp__
-  = EConst Num Loc WidgetDecl
-  | EBase BaseVal
-  | EVar Ident
-  | EFun (List Pat) Exp
-  | EApp Exp (List Exp)
-  | EOp Op (List Exp)
-  | EList (List Exp) (Maybe Exp)
-  | EIndList (List Range)
-  | EIf Exp Exp Exp
-  | ECase Exp (List Branch)
-  | ELet LetKind Rec Pat Exp Exp
-  | EComment String Exp
-  | EOption (P.WithInfo String) (P.WithInfo String) Exp
+  = EConst WS Num Loc WidgetDecl
+  | EBase WS BaseVal
+  | EVar WS Ident
+  | EFun WS (List Pat) Exp WS -- WS: before (, before )
+  | EApp WS Exp (List Exp) WS
+  | EOp WS Op (List Exp) WS
+  | EList WS (List Exp) WS (Maybe Exp) WS
+  | EIndList WS (List Range) WS
+  | EIf WS Exp Exp Exp WS
+  | ECase WS Exp (List Branch) WS
+  | ELet WS LetKind Rec Pat Exp Exp WS
+  | EComment WS String Exp
+  | EOption WS (P.WithInfo String) WS (P.WithInfo String) Exp
 
     -- EFun [] e     impossible
     -- EFun [p] e    (\p. e)
@@ -78,13 +78,15 @@ type Exp__
     -- EApp f [x]    (f x)
     -- EApp f xs     (f x1 ... xn) === ((... ((f x1) x2) ...) xn)
 
-type alias Branch_ = (Pat, Exp)
+type alias WS = String
+
+type Branch_ = Branch_ WS Pat Exp WS
 
 type LetKind = Let | Def
 type alias Rec = Bool
 
 type Range_ -- right now, Exps are always EConsts
-  = Interval Exp Exp
+  = Interval Exp WS Exp
   | Point Exp
 
 type alias WidgetDecl = P.WithInfo WidgetDecl_
@@ -138,8 +140,8 @@ strBaseVal v = case v of
 
 strRange : Bool -> Int -> Range -> String
 strRange showLocs k r = case r.val of
-  Point e        -> sExp_ showLocs k e
-  Interval e1 e2 -> sExp_ showLocs k e1 ++ ".." ++ sExp_ showLocs k e2
+  Point e           -> sExp_ showLocs k e
+  Interval e1 ws e2 -> sExp_ showLocs k e1 ++ ".." ++ sExp_ showLocs k e2
 
 strVal     = strVal_ False
 strValLocs = strVal_ True
@@ -168,7 +170,7 @@ strOp op = case op of
   Mult          -> "*"
   Div           -> "/"
   Lt            -> "<"
-  Eq            -> " = "
+  Eq            -> "="
   Pi            -> "pi"
   Cos           -> "cos"
   Sin           -> "sin"
@@ -194,8 +196,8 @@ strTrace tr = case tr of
       [strOp op, " ", String.join " " (List.map strTrace l)])
 
 strPat p = case p.val of
-  PVar x _   -> x -- TODO strWidgetDecl wd, but not called anyway
-  PList ps m -> let s = Utils.spaces (List.map strPat ps) in
+  PVar _ x _       -> x -- TODO strWidgetDecl wd, but not called anyway
+  PList _ ps _ m _ -> let s = Utils.spaces (List.map strPat ps) in
                 case m of
                   Nothing   -> Utils.bracks s
                   Just rest -> Utils.bracks (s ++ " | " ++ strPat rest)
@@ -215,21 +217,21 @@ sExp_ showLocs k e =
   let sTrace = if showLocs then Utils.braces (toString e.val.eid) else "" in
   sTrace ++
   case e.val.e__ of
-    EBase v -> strBaseVal v
-    EConst i l _ -> -- TODO
+    EBase _ v -> strBaseVal v
+    EConst _ i l _ -> -- TODO
       let (_,b,_) = l in
       toString i
         ++ b
         ++ if showLocs then Utils.braces (strLoc l) else ""
-    EVar x -> x
-    EFun [p] e ->
+    EVar _ x -> x
+    EFun _ [p] e _ ->
       Utils.parens <| "\\" ++ strPat p ++ indent e
-    EFun ps e ->
+    EFun _ ps e _ ->
       let args = Utils.spaces (List.map strPat ps) in
       Utils.parens <| "\\" ++ Utils.parens args ++ indent e
-    EApp e1 [e2] ->
+    EApp _ e1 [e2] _ ->
       Utils.parens <| foo k e1 ++ " " ++ indent e2
-    EApp e1 es ->
+    EApp _ e1 es _ ->
       Utils.parens <|
         let s1 = foo k e1
             ss = List.map (foo (k+1)) es
@@ -237,9 +239,9 @@ sExp_ showLocs k e =
         if fitsOnLine s2
         then s1 ++ " " ++ s2
         else String.join ("\n" ++ tab (k+1)) (s1::ss)
-    EOp op es ->
+    EOp _ op es _ ->
       Utils.parens <| String.join " " (strOp op.val :: List.map (foo k) es)
-    EIf e1 e2 e3 ->
+    EIf _ e1 e2 e3 _ ->
       let s =
         Utils.parens <| Utils.spaces [ "if", foo k e1, foo k e2, foo k e3 ] in
       if fitsOnLine s then s
@@ -248,7 +250,7 @@ sExp_ showLocs k e =
         "if " ++ foo k e1 ++ "\n" ++
           tab (k+1) ++ foo (k+1) e2 ++ "\n" ++
           tab (k+1) ++ foo (k+1) e3
-    EList es mrest ->
+    EList _ es _ mrest _ ->
       Utils.bracks <|
         let ss = List.map (foo k) es
             s  = Utils.spaces ss in
@@ -261,32 +263,32 @@ sExp_ showLocs k e =
           case mrest of
             Nothing -> s
             Just e  -> s ++ "\n" ++ tab k ++ "|" ++ foo k e
-    EIndList rs ->
+    EIndList _ rs _ ->
       Utils.ibracks <|
         let rstrs = List.map (strRange showLocs k) rs
             totstr = Utils.spaces rstrs
         in if fitsOnLine totstr then
           totstr
         else String.join ("\n" ++ tab k ++ " ") rstrs
-    ELet Let b p e1 e2 ->
+    ELet _ Let b p e1 e2 _ ->
       Utils.parens <|
         let k' = if isLet e2 then k else k + 1 in
         (if b then "letrec " else "let ") ++ strPat p ++
           indent e1 ++ "\n" ++
           tab k' ++ foo k' e2
-    ELet Def b p e1 e2 ->
+    ELet _ Def b p e1 e2 _ ->
       let s = if b then "defrec " else "def " in
       Utils.parens (s ++ strPat p ++ indent e1) ++ "\n" ++
       tab k ++ foo k e2
-    ECase e1 l ->
-      let bar (pi,ei) =
+    ECase _ e1 l _ ->
+      let bar (Branch_ ws1 pi ei ws2) =
         tab (k+1) ++ Utils.parens (strPat pi ++ " " ++ foo (k+1) ei) in
       Utils.parens <|
         "case " ++ foo k e1 ++ "\n" ++ Utils.lines (List.map (bar << .val) l)
-    EComment s e1 ->
+    EComment _ s e1 ->
       ";" ++ s ++ "\n" ++
       tab k ++ foo k e1
-    EOption s1 s2 e1 ->
+    EOption _ s1 _ s2 e1 ->
       "# " ++ s1.val ++ ": " ++ s2.val ++ "\n" ++
       tab k ++ foo k e1
 
@@ -303,9 +305,9 @@ fitsOnLine s =
   else True
 
 isLet e = case e.val.e__ of
-  ELet _ _ _ _ _  -> True
-  EComment _ e1 -> isLet e1
-  _             -> False
+  ELet _ _ _ _ _ _ _ -> True
+  EComment _ _ e1    -> isLet e1
+  _                  -> False
 
 
 ------------------------------------------------------------------------------
@@ -324,23 +326,30 @@ mapExp f e =
   let wrapAndMap = f << wrap in
   -- let g e__ = P.WithInfo (Exp_ (f e__) e.val.eid) e.start e.end in
   case e.val.e__ of
-    EConst _ _ _   -> f e
-    EBase _        -> f e
-    EVar _         -> f e
-    EFun ps e'     -> wrapAndMap (EFun ps (recurse e'))
-    EApp e1 es     -> wrapAndMap (EApp (recurse e1) (List.map recurse es))
-    EOp op es      -> wrapAndMap (EOp op (List.map recurse es))
-    EList es m     -> wrapAndMap (EList (List.map recurse es) (Utils.mapMaybe recurse m))
-    EIndList rs    -> let rangeRecurse r_ = case r_ of
-                        Interval e1 e2 -> Interval (recurse e1) (recurse e2)
-                        Point e1       -> Point (recurse e1)
+    EConst _ _ _ _         -> f e
+    EBase _ _              -> f e
+    EVar _ _               -> f e
+    EFun ws1 ps e' ws2     -> wrapAndMap (EFun ws1 ps (recurse e') ws2)
+    EApp ws1 e1 es ws2     -> wrapAndMap (EApp ws1 (recurse e1) (List.map recurse es) ws2)
+    EOp ws1 op es ws2      -> wrapAndMap (EOp ws1 op (List.map recurse es) ws2)
+    EList ws1 es ws2 m ws3 -> wrapAndMap (EList ws1 (List.map recurse es) ws2 (Utils.mapMaybe recurse m) ws3)
+    EIndList ws1 rs ws2    -> let rangeRecurse r_ = case r_ of
+                        Interval e1 ws e2 -> Interval (recurse e1) ws (recurse e2)
+                        Point e1          -> Point (recurse e1)
                       in
-                      wrapAndMap (EIndList (List.map (mapValField rangeRecurse) rs))
-    EIf e1 e2 e3   -> wrapAndMap (EIf (recurse e1) (recurse e2) (recurse e3))
-    ECase e1 l     -> wrapAndMap (ECase (recurse e1) (List.map (mapValField (\(p,ei) -> (p, recurse ei))) l))
-    EComment s e1  -> wrapAndMap (EComment s (recurse e1))
-    EOption s1 s2 e1 -> wrapAndMap (EOption s1 s2 (recurse e1))
-    ELet k b p e1 e2 -> wrapAndMap (ELet k b p (recurse e1) (recurse e2))
+                      wrapAndMap (EIndList ws1 (List.map (mapValField rangeRecurse) rs) ws2)
+    EIf ws1 e1 e2 e3 ws2      -> wrapAndMap (EIf ws1 (recurse e1) (recurse e2) (recurse e3) ws2)
+    ECase ws1 e1 branches ws2 ->
+      let newE1 = recurse e1 in
+      let newBranches =
+        List.map
+            (mapValField (\(Branch_ bws1 p ei bws2) -> Branch_ bws1 p (recurse ei) bws2))
+            branches
+      in
+      wrapAndMap (ECase ws1 newE1 newBranches ws2)
+    EComment ws s e1         -> wrapAndMap (EComment ws s (recurse e1))
+    EOption ws1 s1 ws2 s2 e1 -> wrapAndMap (EOption ws1 s1 ws2 s2 (recurse e1))
+    ELet ws1 k b p e1 e2 ws2 -> wrapAndMap (ELet ws1 k b p (recurse e1) (recurse e2) ws2)
 
 mapExpViaExp__ : (Exp__ -> Exp__) -> Exp -> Exp
 mapExpViaExp__ f e =
@@ -386,10 +395,14 @@ foldVal f v a = case v.v_ of
   VHole _          -> f v a
 
 -- Fold through preorder traversal
-foldExp : (Exp__ -> a -> a) -> a -> Exp -> a
-foldExp f acc e =
-  let flatE__s = List.map (.e__ << .val) (flattenExpTree e) in
-  List.foldl f acc flatE__s
+foldExp : (Exp -> a -> a) -> a -> Exp -> a
+foldExp f acc exp =
+  List.foldl f acc (flattenExpTree exp)
+
+foldExpViaE__ : (Exp__ -> a -> a) -> a -> Exp -> a
+foldExpViaE__ f acc exp =
+  let f' exp = f exp.val.e__ in
+  foldExp f' acc exp
 
 replaceExpNode : Exp -> Exp -> Exp -> Exp
 replaceExpNode oldNode newNode root =
@@ -420,28 +433,28 @@ findAllWithAncestorsRec predicate ancestors exp =
 childExps : Exp -> List Exp
 childExps e =
   case e.val.e__ of
-    EConst _ _ _ -> []
-    EBase _      -> []
-    EVar _       -> []
-    EFun ps e'   -> [e']
-    EOp op es    -> es
-    EList es m   ->
+    EConst _ _ _ _          -> []
+    EBase _ _               -> []
+    EVar _ _                -> []
+    EFun ws1 ps e' ws2      -> [e']
+    EOp ws1 op es ws2       -> es
+    EList ws1 es ws2 m ws3  ->
       case m of
         Just e  -> es ++ [e]
         Nothing -> es
-    EIndList ranges ->
+    EIndList ws1 ranges ws2 ->
       List.concatMap
         (\range -> case range.val of
-          Interval e1 e2 -> [e1, e2]
-          Point e1       -> [e1]
+          Interval e1 ws e2 -> [e1, e2]
+          Point e1          -> [e1]
         )
         ranges
-    EApp f es        -> f :: es
-    ELet k b p e1 e2 -> [e1, e2]
-    EIf e1 e2 e3     -> [e1, e2, e3]
-    ECase e branches -> e :: (List.map (snd << (.val)) branches)
-    EComment s e1    -> [e1]
-    EOption s1 s2 e1 -> [e1]
+    EApp ws1 f es ws2        -> f :: es
+    ELet ws1 k b p e1 e2 ws2 -> [e1, e2]
+    EIf ws1 e1 e2 e3 ws2     -> [e1, e2, e3]
+    ECase ws1 e branches ws2 -> e :: (branchExps branches)
+    EComment ws s e1         -> [e1]
+    EOption ws1 s1 ws2 s2 e1 -> [e1]
 
 ------------------------------------------------------------------------------
 -- Conversion
@@ -470,69 +483,43 @@ applyESubst : ESubst -> Exp -> Exp
 applyESubst s = applySubst { lsubst = Dict.empty, esubst = s }
 
 applySubst : TwoSubsts -> Exp -> Exp
-applySubst subst e =
-  (\e__ ->
-    let e__' =
-      case Dict.get e.val.eid subst.esubst of
-        Just eNew -> eNew
-        Nothing   -> e__
-    in
-    P.WithInfo (Exp_ e__' e.val.eid) e.start e.end) <|
- case e.val.e__ of
-  EConst n l wd ->
-    case Dict.get (Utils.fst3 l) subst.lsubst of
-      Just i -> EConst i l wd
-      Nothing -> EConst n l wd
-      -- 10/28: substs from createMousePosCallbackSlider only bind
-      -- updated values (unlike substs from Sync)
-  EBase _    -> e.val.e__
-  EVar _     -> e.val.e__
-  EFun ps e' -> EFun ps (applySubst subst e')
-  EOp op es  -> EOp op (List.map (applySubst subst) es)
-  EList es m -> EList (List.map (applySubst subst) es)
-                      (Utils.mapMaybe (applySubst subst) m)
-  EIndList rs ->
-    let f r_ = case r_ of
-      Interval e1 e2 -> Interval (applySubst subst e1) (applySubst subst e2)
-      Point e1       -> Point (applySubst subst e1) in
-    EIndList (List.map (mapValField f) rs)
-  EApp f es  -> EApp (applySubst subst f) (List.map (applySubst subst) es)
-  ELet k b p e1 e2 ->
-    ELet k b p (applySubst subst e1) (applySubst subst e2) -- TODO
-  EIf e1 e2 e3 ->
-    EIf (applySubst subst e1) (applySubst subst e2) (applySubst subst e3)
-  ECase e l ->
-    ECase (applySubst subst e) (List.map (mapValField (\(p,ei) -> (p, applySubst subst ei))) l)
-  EComment s e1 ->
-    EComment s (applySubst subst e1)
-  EOption s1 s2 e1 ->
-    EOption s1 s2 (applySubst subst e1)
+applySubst subst exp =
+  let replacer =
+    (\e ->
+      let e__ = e.val.e__ in
+      let e__ConstReplaced =
+        case e__ of
+          EConst ws n loc wd ->
+            let locId = Utils.fst3 loc in
+            case Dict.get locId subst.lsubst of
+              Just n' -> EConst ws n' loc wd
+              Nothing -> e__
+              -- 10/28: substs from createMousePosCallbackSlider only bind
+              -- updated values (unlike substs from Sync)
+          _ -> e__
+      in
+      let e__' =
+        case Dict.get e.val.eid subst.esubst of
+          Just e__New -> e__New
+          Nothing     -> e__ConstReplaced
+      in
+      P.WithInfo (Exp_ e__' e.val.eid) e.start e.end
+    )
+  in
+  mapExp replacer exp
 
 
 unfrozenLocIdsAndNumbers : Exp -> List (LocId, Num)
-unfrozenLocIdsAndNumbers e =
-  case e.val.e__ of
-    EConst n l wd ->
-      case l of
-        (locId, "!", _) -> []
-        (locId, _,   _) -> [(locId, n)]
-
-    EBase _    -> []
-    EVar _     -> []
-    EFun ps e' -> unfrozenLocIdsAndNumbers e'
-    EOp op es  -> List.concat (List.map unfrozenLocIdsAndNumbers es)
-    EList es m ->
-      case m of
-        Just e  -> List.concat (List.map unfrozenLocIdsAndNumbers es) |> List.append (unfrozenLocIdsAndNumbers e)
-        Nothing -> List.concat (List.map unfrozenLocIdsAndNumbers es)
-
-    EIndList ranges -> []
-    EApp f es  -> List.concat (List.map unfrozenLocIdsAndNumbers es)
-    ELet k b p e1 e2 -> (unfrozenLocIdsAndNumbers e1) ++ (unfrozenLocIdsAndNumbers e2)
-    EIf e1 e2 e3 -> (unfrozenLocIdsAndNumbers e1) ++ (unfrozenLocIdsAndNumbers e2) ++ (unfrozenLocIdsAndNumbers e3)
-    ECase e l -> (unfrozenLocIdsAndNumbers e) ++ List.concat (List.map (\branch -> unfrozenLocIdsAndNumbers (snd branch.val)) l)
-    EComment s e1 -> (unfrozenLocIdsAndNumbers e1)
-    EOption s1 s2 e1 -> (unfrozenLocIdsAndNumbers e1)
+unfrozenLocIdsAndNumbers exp =
+  foldExpViaE__
+    (\e__ acc ->
+      case e__ of
+        EConst _ n (locId, "!", _) _ -> acc
+        EConst _ n (locId,   _, _) _ -> (locId, n) :: acc
+        _                            -> acc
+    )
+    []
+    exp
 
 {-
 -- for now, LocId instead of EId
@@ -551,20 +538,26 @@ applyESubst esubst =
 -----------------------------------------------------------------------------
 -- Utility
 
+branchExps : List Branch -> List Exp
+branchExps branches =
+  List.map
+    (\b -> let (Branch_ _ _ exp _) = b.val in exp)
+    branches
+
 -- Need parent expression since case expression branches into several scopes
 isScope : Maybe Exp -> Exp -> Bool
 isScope maybeParent exp =
   let isObviouslyScope =
     case exp.val.e__ of
-      ELet _ _ _ _ _ -> True
-      EFun _ _       -> True
-      _              -> False
+      ELet _ _ _ _ _ _ _ -> True
+      EFun _ _ _ _       -> True
+      _                  -> False
   in
   case maybeParent of
     Just parent ->
       case parent.val.e__ of
-        (ECase predicate branches) -> predicate /= exp
-        _                          -> isObviouslyScope
+        ECase _ predicate branches _ -> predicate /= exp
+        _                            -> isObviouslyScope
     Nothing -> isObviouslyScope
 
 -----------------------------------------------------------------------------
@@ -574,9 +567,9 @@ isScope maybeParent exp =
 
 getOptions : Exp -> List (String, String)
 getOptions e = case e.val.e__ of
-  EOption s1 s2 e1 -> (s1.val, s2.val) :: getOptions e1
-  EComment _ e1    -> getOptions e1
-  _                -> []
+  EOption _ s1 _ s2 e1 -> (s1.val, s2.val) :: getOptions e1
+  EComment _ _ e1      -> getOptions e1
+  _                    -> []
 
 
 ------------------------------------------------------------------------------
@@ -611,37 +604,37 @@ dummyTrace_ b = TrLoc (dummyLoc_ b)
 dummyLoc = dummyLoc_ unann
 dummyTrace = dummyTrace_ unann
 
-ePlus e1 e2 = withDummyPos <| EOp (withDummyRange Plus) [e1,e2]
+ePlus e1 e2 = withDummyPos <| EOp "" (withDummyRange Plus) [e1,e2] ""
 
-eBool  = withDummyPos << EBase << Bool
+eBool  = withDummyPos << EBase " " << Bool
 eTrue  = eBool True
 eFalse = eBool False
 
 eApp e es = case es of
   []      -> Debug.crash "eApp"
-  [e1]    -> withDummyPos <| EApp e [e1]
-  e1::es' -> eApp (withDummyPos <| EApp e [e1]) es'
+  [e1]    -> withDummyPos <| EApp "\n" e [e1] ""
+  e1::es' -> eApp (withDummyPos <| EApp " " e [e1] "") es'
 
 eFun ps e = case ps of
   []      -> Debug.crash "eFun"
-  [p]     -> withDummyPos <| EFun [p] e
-  p::ps'  -> withDummyPos <| EFun [p] (eFun ps' e)
+  [p]     -> withDummyPos <| EFun " " [p] e ""
+  p::ps'  -> withDummyPos <| EFun " " [p] (eFun ps' e) ""
 
-ePair e1 e2 = withDummyPos <| EList [e1,e2] Nothing
+ePair e1 e2 = withDummyPos <| EList " " [e1,e2] "" Nothing ""
 
 noWidgetDecl = withDummyRange NoWidgetDecl
 
 eLets xes eBody = case xes of
   (x,e)::xes' -> withDummyPos <|
-                   ELet Let False (withDummyRange (PVar x noWidgetDecl)) e (eLets xes' eBody)
+                   ELet "\n" Let False (withDummyRange (PVar " " x noWidgetDecl)) e (eLets xes' eBody) ""
   []          -> eBody
 
-eVar a         = withDummyPos <| EVar a
-eConst a b     = withDummyPos <| EConst a b noWidgetDecl
-eList a b      = withDummyPos <| EList a b
-eComment a b   = withDummyPos <| EComment a b
+eVar a         = withDummyPos <| EVar " " a
+eConst a b     = withDummyPos <| EConst " " a b noWidgetDecl
+eList a b      = withDummyPos <| EList " " a "" b ""
+eComment a b   = withDummyPos <| EComment " " a b
 
-pVar a         = withDummyRange <| PVar a noWidgetDecl
+pVar a         = withDummyRange <| PVar " " a noWidgetDecl
 
 -- note: dummy ids...
 vTrue    = vBool True

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -391,15 +391,10 @@ foldExp f acc e =
   let flatE__s = List.map (.e__ << .val) (flattenExpTree e) in
   List.foldl f acc flatE__s
 
-replaceNode : Exp -> Exp -> Exp -> Exp
-replaceNode oldNode newNode root =
-  mapExp
-      (\node ->
-        if node == oldNode
-        then newNode
-        else node
-      )
-      root
+replaceExpNode : Exp -> Exp -> Exp -> Exp
+replaceExpNode oldNode newNode root =
+  let esubst = Dict.singleton oldNode.val.eid newNode.val.e__ in
+  applyESubst esubst root
 
 ------------------------------------------------------------------------------
 -- Traversing

--- a/src/LangParser2.elm
+++ b/src/LangParser2.elm
@@ -127,7 +127,7 @@ substOf_ s e = case e.val.e__ of
     let (k,_,_) = l in
     case Dict.get k s of
       Nothing -> Dict.insert k { e | val = i } s
-      Just j  -> if i == j.val then s else Debug.crash "substOf_"
+      Just j  -> if i == j.val then s else Debug.crash <| "substOf_ Constant: " ++ (toString i)
   EBase _    -> s
   EVar _     -> s
   EFun _ e'  -> substOf_ s e'

--- a/src/LangParser2.elm
+++ b/src/LangParser2.elm
@@ -166,7 +166,7 @@ unwrapChars = List.map .val << .val
 
 isAlpha c        = Char.isLower c || Char.isUpper c
 isAlphaNumeric c = Char.isLower c || Char.isUpper c || Char.isDigit c
-isWhitespace c   = c == ' ' || c == '\n'
+isWhitespace c   = c == ' ' || c == '\n' || c == '\t'
 
 parseInt : P.Parser Int
 parseInt =
@@ -303,7 +303,7 @@ parseList1 = parseList_ P.sepBy1
 
 parseListLiteral p f = parseList "[" listSep "]" p f
 
-listSep = P.token " " <++ P.token "\n" -- duplicating isWhitespace...
+listSep = P.token " " <++ P.token "\n" <++ P.token "\t" -- duplicating isWhitespace...
 
 parseMultiCons
    : P.Parser a -> (List (P.WithInfo a) -> P.WithInfo a -> b)

--- a/src/LangSvg.elm
+++ b/src/LangSvg.elm
@@ -479,7 +479,7 @@ fetchSlideVal slideNumber val =
       -- Program returned the slide count and a
       -- function from slideNumber -> SVG array structure.
       case pat.val of -- Find that function's argument name
-        PVar argumentName _ ->
+        PVar _ argumentName _ ->
           -- Bind the slide number to the function's argument.
           let fenv' = (argumentName, vConst (toFloat slideNumber, dummyTrace)) :: fenv in
           let ((returnVal, _), _) = Eval.eval fenv' fexp in
@@ -493,7 +493,7 @@ fetchMovieVal movieNumber slideVal =
   case unwrapVList slideVal of
     Just [VConst (movieCount, _), VClosure _ pat fexp fenv] ->
       case pat.val of -- Find the function's argument name
-        PVar movieNumberArgumentName _ ->
+        PVar _ movieNumberArgumentName _ ->
           let fenv' = (movieNumberArgumentName, vConst (toFloat movieNumber, dummyTrace)) :: fenv in
           let ((returnVal, _), _) = Eval.eval fenv' fexp in
           returnVal
@@ -516,13 +516,13 @@ fetchMovieFrameVal slideNumber movieNumber movieTime movieVal =
   case unwrapVList movieVal of
     Just [VBase (String "Static"), VClosure _ pat fexp fenv] ->
       case pat.val of -- Find the function's argument names
-        PVar slideNumberArgumentName _ ->
+        PVar _ slideNumberArgumentName _ ->
           let fenv' = (slideNumberArgumentName, vConst (toFloat slideNumber, dummyTrace)) :: fenv in
           let ((innerVal, _), _) = Eval.eval fenv' fexp in
           case innerVal.v_ of
             VClosure _ patInner fexpInner fenvInner ->
               case patInner.val of
-                PVar movieNumberArgumentName _ ->
+                PVar _ movieNumberArgumentName _ ->
                   let fenvInner' = (movieNumberArgumentName, vConst (toFloat movieNumber, dummyTrace)) :: fenvInner in
                   let ((returnVal, _), _) = Eval.eval fenvInner' fexpInner in
                   returnVal
@@ -531,19 +531,19 @@ fetchMovieFrameVal slideNumber movieNumber movieTime movieVal =
         _ -> Debug.crash ("expected static movie frame function to take two arguments, got " ++ (toString pat.val))
     Just [VBase (String "Dynamic"), VConst (movieDuration, _), VClosure _ pat fexp fenv, VBase (Bool _)] ->
       case pat.val of -- Find the function's argument names
-        PVar slideNumberArgumentName _ ->
+        PVar _ slideNumberArgumentName _ ->
           let fenv' = (slideNumberArgumentName, vConst (toFloat slideNumber, dummyTrace)) :: fenv in
           let ((innerVal1, _), _) = Eval.eval fenv' fexp in
           case innerVal1.v_ of
             VClosure _ patInner1 fexpInner1 fenvInner1 ->
               case patInner1.val of
-                PVar movieNumberArgumentName _ ->
+                PVar _ movieNumberArgumentName _ ->
                   let fenvInner1' = (movieNumberArgumentName, vConst (toFloat movieNumber, dummyTrace)) :: fenvInner1 in
                   let ((innerVal2, _), _) = Eval.eval fenvInner1' fexpInner1 in
                   case innerVal2.v_ of
                     VClosure _ patInner2 fexpInner2 fenvInner2 ->
                       case patInner2.val of
-                        PVar movieSecondsArgumentName _ ->
+                        PVar _ movieSecondsArgumentName _ ->
                           let fenvInner2' = (movieSecondsArgumentName, vConst (movieTime, dummyTrace)) :: fenvInner2 in
                           let ((returnVal, _), _) = Eval.eval fenvInner2' fexpInner2 in
                           returnVal

--- a/src/LangUnparser.elm
+++ b/src/LangUnparser.elm
@@ -1,4 +1,4 @@
-module LangUnparser (unparse, bumpCol, incCol) where
+module LangUnparser (unparse, bumpCol, incCol, preceedingWhitespace) where
 
 import Lang exposing (..)
 import OurParser2 exposing (Pos, WithPos, WithInfo, startPos)
@@ -20,6 +20,23 @@ bumpCol n pos = { pos | col = n + pos.col }
 incCol = bumpCol 1
 
 ------------------------------------------------------------------------------
+
+preceedingWhitespace : Exp -> String
+preceedingWhitespace e =
+  case e.val.e__ of
+    EBase    ws v                     -> ws
+    EConst   ws n l wd                -> ws
+    EVar     ws x                     -> ws
+    EFun     ws1 ps e1 ws2            -> ws1
+    EApp     ws1 e1 es ws2            -> ws1
+    EList    ws1 es ws2 rest ws3      -> ws1
+    EIndList ws1 rs ws2               -> ws1
+    EOp      ws1 op es ws2            -> ws1
+    EIf      ws1 e1 e2 e3 ws2         -> ws1
+    ELet     ws1 kind rec p e1 e2 ws2 -> ws1
+    ECase    ws1 e1 bs ws2            -> ws1
+    EComment ws s e1                  -> ws
+    EOption  ws1 s1 ws2 s2 e1         -> ws1
 
 unparseWD : WidgetDecl -> String
 unparseWD wd =

--- a/src/LangUnparser.elm
+++ b/src/LangUnparser.elm
@@ -1,4 +1,4 @@
-module LangUnparser (unparse, bumpCol, incCol, preceedingWhitespace) where
+module LangUnparser (unparse, bumpCol, incCol, preceedingWhitespace, addPreceedingWhitespace) where
 
 import Lang exposing (..)
 import OurParser2 exposing (Pos, WithPos, WithInfo, startPos)
@@ -37,6 +37,28 @@ preceedingWhitespace e =
     ECase    ws1 e1 bs ws2            -> ws1
     EComment ws s e1                  -> ws
     EOption  ws1 s1 ws2 s2 e1         -> ws1
+
+addPreceedingWhitespace : String -> Exp -> Exp
+addPreceedingWhitespace newWs exp =
+  let e__' =
+    case exp.val.e__ of
+      EBase    ws v                     -> EBase    (newWs ++ ws) v
+      EConst   ws n l wd                -> EConst   (newWs ++ ws) n l wd
+      EVar     ws x                     -> EVar     (newWs ++ ws) x
+      EFun     ws1 ps e1 ws2            -> EFun     (newWs ++ ws1) ps e1 ws2
+      EApp     ws1 e1 es ws2            -> EApp     (newWs ++ ws1) e1 es ws2
+      EList    ws1 es ws2 rest ws3      -> EList    (newWs ++ ws1) es ws2 rest ws3
+      EIndList ws1 rs ws2               -> EIndList (newWs ++ ws1) rs ws2
+      EOp      ws1 op es ws2            -> EOp      (newWs ++ ws1) op es ws2
+      EIf      ws1 e1 e2 e3 ws2         -> EIf      (newWs ++ ws1) e1 e2 e3 ws2
+      ELet     ws1 kind rec p e1 e2 ws2 -> ELet     (newWs ++ ws1) kind rec p e1 e2 ws2
+      ECase    ws1 e1 bs ws2            -> ECase    (newWs ++ ws1) e1 bs ws2
+      EComment ws s e1                  -> EComment (newWs ++ ws) s e1
+      EOption  ws1 s1 ws2 s2 e1         -> EOption  (newWs ++ ws1) s1 ws2 s2 e1
+  in
+  let val = exp.val in
+  { exp | val = { val | e__ = e__' } }
+
 
 unparseWD : WidgetDecl -> String
 unparseWD wd =

--- a/src/LangUnparser.elm
+++ b/src/LangUnparser.elm
@@ -1,4 +1,4 @@
-module LangUnparser (unparseE, bumpCol, incCol) where
+module LangUnparser (unparse, bumpCol, incCol) where
 
 import Lang exposing (..)
 import OurParser2 exposing (Pos, WithPos, WithInfo, startPos)
@@ -14,243 +14,78 @@ debugLog = Config.debugLog Config.debugParser
 
 ------------------------------------------------------------------------------
 
--- NOTES:
---  - Lang/LangParser2 is set up such that trailing whitespace on each line
---    is not reinstated
+-- TODO: I think these can go away...
 
-bumpLine n pos = { line = n + pos.line, col = 1 }
-bumpCol  n pos = { pos | col = n + pos.col }
-
-incLine = bumpLine 1
-incCol  = bumpCol 1
-decCol  = bumpCol (-1)
-
-lines i j =
-  -- | i > j     -> Debug.crash <| "Unparser.lines: " ++ toString (i,j)
-  -- TODO to help Sync.relateWithVar for now
-  if i > j
-    then " "
-    else String.repeat (j-i) "\n"
-
-cols i j =
-  -- | i > j     -> Debug.crash <| "Unparser.cols: " ++ toString (i,j)
-  -- TODO to help Sync.expandRange for now
-  if i > j
-    then let _ = Debug.log "Unparser.cols: " (toString (i, j)) in " "
-    else String.repeat (j-i) " "
-
-whitespace : Pos -> Pos -> String
-whitespace endPrev startNext =
-  debugLog ("whiteSpace " ++ toString (endPrev, startNext)) <|
-    if endPrev.line == startNext.line
-    then cols endPrev.col startNext.col
-    else lines endPrev.line startNext.line ++ cols 1 startNext.col
-
-delimit : String -> String -> Pos -> Pos -> Pos -> Pos -> String -> String
-delimit open close startOutside startInside endInside endOutside s =
-  let olen = String.length open
-      clen = String.length close in
-  Utils.delimit open close
-    <| whitespace (bumpCol olen startOutside) startInside
-    ++ s
-    ++ whitespace endInside (bumpCol (-1 * clen) endOutside)
-
-parens = delimit "(" ")"
-
-space = whitespace   -- at least one " "
-
--- NOTE: delimit/space functions that build on this are at the end
+bumpCol n pos = { pos | col = n + pos.col }
+incCol = bumpCol 1
 
 ------------------------------------------------------------------------------
+
+unparseWD : WidgetDecl -> String
+unparseWD wd =
+  case wd.val of
+    NoWidgetDecl        -> ""
+    IntSlider a tok b _ -> "{" ++ toString a.val ++ tok.val ++ toString b.val ++ "}"
+    NumSlider a tok b _ -> "{" ++ toString a.val ++ tok.val ++ toString b.val ++ "}"
 
 unparsePat : Pat -> String
 unparsePat p = case p.val of
-  PVar x wd -> case wd.val of
-    NoWidgetDecl        -> x
-    IntSlider a tok b _ -> x ++ bracesAndSpaces wd.start wd.end [UInt a, UStr tok, UInt b]
-    NumSlider a tok b _ -> x ++ bracesAndSpaces wd.start wd.end [UNum a, UStr tok, UNum b]
-  PList ps Nothing ->
-    bracksAndSpaces p.start p.end (List.map UPat ps)
-  PList ps (Just pRest) ->
-    -- let _ = Debug.log "TODO: unparsePat" () in
-    strPat p
-  PConst n -> strNum n
-  PBase bv -> strBaseVal bv
-
--- NOTE:
---   haven't recorded pos for "\", "let", "case", "if", etc.
---   so makeToken picks a canonical position
-
-makeToken start s =
-  let n = String.length s in
-  WithInfo s start (bumpCol n start)
-
--- TODO: compute whitespace once per AST-skeleton
+  PVar ws x wd ->
+    ws ++ x ++ unparseWD wd
+  PList ws1 ps ws2 Nothing ws3 ->
+    ws1 ++ "[" ++ (String.concat (List.map unparsePat ps)) ++ ws3 ++ "]"
+  PList ws1 ps ws2 (Just pRest) ws3 ->
+    ws1 ++ "[" ++ (String.concat (List.map unparsePat ps)) ++ ws2 ++ "|" ++ unparsePat pRest ++ ws3 ++ "]"
+  PConst ws n -> ws ++ strNum n
+  PBase ws bv -> ws ++ strBaseVal bv
 
 unparse : Exp -> String
 unparse e = case e.val.e__ of
-  EBase v -> strBaseVal v
-  EConst i l wd ->
-    let s = let (_,b,_) = l in toString i ++ b in
-    case wd.val of
-      NoWidgetDecl        -> s
-      IntSlider a tok b _ -> s ++ bracesAndSpaces wd.start wd.end [UInt a, UStr tok, UInt b]
-      NumSlider a tok b _ -> s ++ bracesAndSpaces wd.start wd.end [UNum a, UStr tok, UNum b]
+  EBase ws v -> ws ++ strBaseVal v
+  EConst ws n l wd ->
+    let (_,b,_) = l in
+    ws ++ toString n ++ b ++ unparseWD wd
     -- TODO: parse/unparse are not inverses for floats (e.g. 1.0)
-  EVar x -> x
-  EFun [p] e1 ->
-    let tok = makeToken (incCol e.start) "\\" in
-    parensAndSpaces e.start e.end [UStr tok, UPat p, UExp e1]
-  EFun ps e1 ->
-    let tok = makeToken (incCol e.start) "\\" in
-    parensAndSpaces e.start e.end [UStr tok, UParens (List.map UPat ps), UExp e1]
-  EApp e1 es -> parensAndSpaces e.start e.end (List.map UExp (e1::es))
-  EList es Nothing -> bracksAndSpaces e.start e.end (List.map UExp es)
-  EList es (Just eRest) ->
-    let en = Utils.head_ <| List.reverse es in
-    let tok1 = makeToken e.start   "[" in
-    let tok2 = makeToken en.end    "|" in
-    let tok3 = makeToken eRest.end "]" in
-       delimitAndSpaces tok1.val tok2.val tok1.start tok2.end (List.map UExp es)
-    ++ space tok2.end eRest.start
-    ++ unparse eRest ++ space eRest.end tok3.start
-    ++ tok3.val
-  EIndList rs ->
-    ibracksAndSpaces e.start e.end (List.concat (List.map unparseRange rs))
-{-
-  EOp op es ->
-    let sOp = { op | val = strOp op.val } in
-    parensAndSpaces e.start e.end (UStr sOp :: List.map UExp es)
--}
-  EOp op es ->
-    let normal () =
-      let sOp = { op | val = strOp op.val } in
-      parensAndSpaces e.start e.end (UStr sOp :: List.map UExp es)
-    in
-    -- TODO: hack to fix unparsing issue after Sync.relateNumsWithVar...
-    case (op.val, List.map (.e__ << .val) es) of
-      (Plus, [EVar x, _]) ->
-        case Utils.munchString "gensym" x of
-          Just _  -> sExp e
-          Nothing -> normal ()
-      _           -> normal ()
-  EIf e1 e2 e3 ->
-    let tok = makeToken (incCol e.start) "if" in
-    parensAndSpaces e.start e.end (UStr tok :: List.map UExp [e1,e2,e3])
-  ELet Let b p e1 e2 ->
-    let tok = makeToken (incCol e.start) (if b then "letrec" else "let") in
-    parensAndSpaces e.start e.end (UStr tok :: UPat p :: List.map UExp [e1,e2])
-  ELet Def b p e1 e2 ->
+  EVar ws x -> ws ++ x
+  EFun ws1 [p] e1 ws2 ->
+    ws1 ++ "(\\" ++ unparsePat p ++ unparse e1 ++ ws2 ++ ")"
+  EFun ws1 ps e1 ws2 ->
+    ws1 ++ "(\\(" ++ (String.concat (List.map unparsePat ps)) ++ ")" ++ unparse e1 ++ ws2 ++ ")"
+  EApp ws1 e1 es ws2 ->
+    ws1 ++ "(" ++ unparse e1 ++ (String.concat (List.map unparse es)) ++ ws2 ++ ")"
+  EList ws1 es ws2 Nothing ws3 ->
+    ws1 ++ "[" ++ (String.concat (List.map unparse es)) ++ ws3 ++ "]"
+  EList ws1 es ws2 (Just eRest) ws3 ->
+    ws1 ++ "[" ++ (String.concat (List.map unparse es)) ++ ws2 ++ "|" ++ unparse eRest ++ ws3 ++ "]"
+  EIndList ws1 rs ws2 ->
+    ws1 ++ "[|" ++ (String.concat (List.map unparseRange rs)) ++ ws2 ++ "|]"
+  EOp ws1 op es ws2 ->
+    ws1 ++ "(" ++ strOp op.val ++ (String.concat (List.map unparse es)) ++ ws2 ++ ")"
+  EIf ws1 e1 e2 e3 ws2 ->
+    ws1 ++ "(if" ++ unparse e1 ++ unparse e2 ++ unparse e3 ++ ws2 ++ ")"
+  ELet ws1 Let b p e1 e2 ws2 ->
+    let tok = if b then "letrec" else "let" in
+    ws1 ++ "(" ++ tok ++ unparsePat p ++ unparse e1 ++ unparse e2 ++ ws2 ++ ")"
+  ELet ws1 Def b p e1 e2 ws2 ->
     -- TODO don't used nested defs until this is re-worked
-    let tok = makeToken (incCol e.start) (if b then "defrec" else "def") in
-    let s1 = parensAndSpaces e.start e.end [UStr tok, UPat p, UExp e1] in
-    s1 ++ space e.end e2.start ++ unparse e2
-  ECase e1 l ->
-    let tok = makeToken (incCol e.start) "case" in
-    parensAndSpaces e.start e.end (UStr tok :: UExp e1 :: List.map UBra l)
-  EComment s e1 ->
-    let white = whitespace (incLine e.start) e1.start in
-    ";" ++ s ++ "\n" ++ white ++ unparse e1
-  EOption s1 s2 e1 ->
-    let tok1 = makeToken e.start "#" in
-    let tok2 = makeToken s1.end ":" in
-    let s = fst (spaces (List.map UStr [tok1, s1, tok2, s2])) in
-    let white = whitespace (incLine e.start) e1.start in
-    s ++ "\n" ++ white ++ unparse e1
+    let tok = if b then "defrec" else "def" in
+    ws1 ++ "(" ++ tok ++ unparsePat p ++ unparse e1 ++ ws2 ++ ")" ++ unparse e2
+  ECase ws1 e1 bs ws2 ->
+    let branchesStr =
+      String.concat
+        <| List.map (\(Branch_ bws1 pat exp bws2) -> bws1 ++ "(" ++ unparsePat pat ++ unparse exp ++ bws2 ++ ")")
+        <| List.map (.val) bs
+    in
+    ws1 ++ "(case" ++ unparse e1 ++ branchesStr ++ ws2 ++ ")"
+  EComment ws s e1 ->
+    ws ++ ";" ++ s ++ "\n" ++ unparse e1
+  EOption ws1 s1 ws2 s2 e1 ->
+    ws1 ++ "# " ++ s1.val ++ ":" ++ ws2 ++ s2.val ++ "\n" ++ unparse e1
 
-unparseE : Exp -> String
-unparseE e = whitespace startPos e.start ++ unparse e
-
--- Currently only remembers whitespace after ".."
-unparseRange : Range -> List Unparsable
+unparseRange : Range -> String
 unparseRange r = case r.val of
-  Point e        -> [ UExp e ]
-  Interval e1 e2 -> [ UExp e1, UStr (makeToken e1.end ".."), UExp e2 ]
+  Point e           -> unparse e
+  Interval e1 ws e2 -> unparse e1 ++ ws ++ ".." ++ unparse e2
 
 -- NOTE: use this to go back to original unparser
--- unparseE = sExp
-
-------------------------------------------------------------------------------
-
-{-
-
-NOTE:
-  Defining Unparsable at the end, since otherwise there's the following
-  undefined error (probably due to the mutual recursion):
-
-  Cannot read property 'arity' of undefined
-
--}
-
-type Unparsable
-  = UExp (WithInfo Exp_)    -- = Exp
-  | UPat (WithInfo Pat_)    -- = Pat
-  | UBra (WithInfo Branch_) -- = Branch
-  | UStr (WithInfo String)
-  | UInt (WithInfo Int)
-  | UNum (WithInfo Num)
-  | UParens (List Unparsable)
-      -- no start/pos info, so using first/last elements as
-      -- canonical positions
-
-strU thing = case thing of
-  UExp e -> unparse e
-  UPat p -> unparsePat p
-  UStr s -> identity s.val
-  UInt i -> toString i.val
-  UNum i -> strNum i.val
-  UBra b ->
-    let (p,e) = b.val in
-    let s = unparsePat p ++ space p.end e.start ++ unparse e in
-    parens b.start p.start e.end b.end s
-  UParens l ->
-    let (start, end) = (startU thing, endU thing) in
-    parens start (incCol start) (decCol end) end (fst (spaces l))
-
-startU thing = case thing of
-  UExp x -> x.start
-  UPat x -> x.start
-  UStr x -> x.start
-  UInt x -> x.start
-  UNum x -> x.start
-  UBra x -> x.start
-
-  UParens l -> let first = Utils.head_ l in decCol (startU first)
-
-endU thing = case thing of
-  UExp x -> x.end
-  UPat x -> x.end
-  UStr x -> x.end
-  UInt x -> x.end
-  UNum x -> x.end
-  UBra x -> x.end
-
-  UParens l -> let last = Utils.head_ (List.reverse l) in incCol (endU last)
-
-spaces : List Unparsable -> (String, Pos)
-spaces things =
-  let (hd,tl) = Utils.uncons things in
-  let foo cur (acc, endPrev) =
-    let acc'     = strU cur :: space endPrev (startU cur) :: acc in
-    let endPrev' = endU cur in
-    (acc', endPrev')
-  in
-  let (l, endLast) = List.foldl foo ([strU hd], endU hd) tl in
-  (String.join "" (List.reverse l), endLast)
-
-delimitAndSpaces : String -> String -> Pos -> Pos -> List Unparsable -> String
-delimitAndSpaces open close start end things =
-  let olen = String.length open
-      clen = String.length close in
-  case things of
-    [] ->
-      open ++ whitespace (bumpCol olen start) (bumpCol (-1 * clen) end) ++ close
-    hd :: _ ->
-      let startFirst   = startU hd in
-      let (s, endLast) = spaces things in
-      delimit open close start startFirst endLast end s
-
-parensAndSpaces = delimitAndSpaces "(" ")"
-bracksAndSpaces = delimitAndSpaces "[" "]"
-bracesAndSpaces = delimitAndSpaces "{" "}"
-ibracksAndSpaces = delimitAndSpaces "[|" "|]"
+-- unparse = sExp

--- a/src/Sync.elm
+++ b/src/Sync.elm
@@ -6,7 +6,9 @@ module Sync (Options, defaultOptions, syncOptionsOf,
              relateSelectedAttrs,
              relate,
              strCall,
-             printZoneTable, LiveInfo, Triggers, tryToBeSmart) where
+             printZoneTable, LiveInfo, Triggers, tryToBeSmart,
+             locsOfTrace
+             ) where
 
 import Dict exposing (Dict)
 import Set
@@ -538,7 +540,7 @@ removeDeadIndices e v' =
     EIndList rs -> EList (List.concatMap (expandRange idxTraces) rs) Nothing
     _           -> e__
   in
-  mapExp foo e
+  mapExpViaExp__ foo e
 
 expandRange idxTraces r =
   let mem = flip List.member idxTraces in

--- a/src/Sync.elm
+++ b/src/Sync.elm
@@ -1724,8 +1724,8 @@ evalTr subst tr = Utils.fromJust_ "evalTr" (evalTrace subst tr)
 
 ------------------------------------------------------------------------------
 
-setFromLists : List Locs -> LocSet
-setFromLists = List.foldl (flip Set.union << Set.fromList) Set.empty
+setFromLocLists : List Locs -> LocSet
+setFromLocLists = List.foldl (flip Set.union << Set.fromList) Set.empty
 
 -- TODO compute this along with everything else
 -- could also make this a single dictionary: Dict (NodeId, Zone) Locs
@@ -1736,7 +1736,7 @@ zoneAssignments =
       case m of
         Just (locs,otherLocs) ->
           let yellowLocs = Set.fromList locs in
-          let grayLocs   = setFromLists otherLocs `Set.diff` yellowLocs in
+          let grayLocs   = setFromLocLists otherLocs `Set.diff` yellowLocs in
           Dict.insert z (yellowLocs, grayLocs) acc
         Nothing       -> acc
     ) Dict.empty l

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -28,6 +28,8 @@ update (k1, v1) vals =
         then (k0, v1) :: vs
         else (k0, v0) :: update (k1, v1) vs
 
+-- Extra elements left off if the lists are different lengths.
+-- Resulting list length is minimum of (length xs, length ys)
 zip : List a -> List b -> List (a,b)
 zip xs ys = case (xs, ys) of
   (x::xs', y::ys') -> (x,y) :: zip xs' ys'

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -257,6 +257,19 @@ setIsEmpty  = (==) [] << Set.toList
 dictIsEmpty = (==) [] << Dict.toList
 setCardinal = List.length << Set.toList
 
+-- Common elements shared at the beginning of each list
+commonPrefix : List (List a) -> List a
+commonPrefix lists =
+  case lists of
+    first::rest -> List.foldl commonPrefix2 first rest
+    []          -> []
+
+commonPrefix2 : List a -> List a -> List a
+commonPrefix2 l1 l2 =
+  case (l1, l2) of
+    (x::xs, y::ys) -> if x == y then x::(commonPrefix2 xs ys) else []
+    _              -> []
+
 between x (a,b) = a <= x && x < b
 
 distance (x1,y1) (x2,y2) = sqrt <| (x2-x1)^2 + (y2-y1)^2

--- a/tests/ExampleTests.elm
+++ b/tests/ExampleTests.elm
@@ -1,0 +1,43 @@
+module ExampleTests where
+
+import String
+
+import ExamplesGenerated as Examples
+
+import LangParser2 exposing (parseE)
+import Eval
+import LangUnparser
+
+testEvalsWithoutErrors name code =
+  case parseE code of
+    Err s ->
+      "can't parse " ++ name ++ ": " ++ s ++ "\n" ++ code
+    Ok exp ->
+      -- Elm will crash first if Eval fails.
+      case Eval.run exp of
+        (val, widgets) -> "ok"
+
+testReparsedUnparsedEvalsWithoutErrors name code =
+  case parseE code of
+    Err s ->
+      "can't parse " ++ name ++ ": " ++ s ++ "\n" ++ code
+    Ok parsed ->
+      let unparsed = LangUnparser.unparse parsed in
+      case parseE unparsed of
+        Err s ->
+          "can't re-parse unparsed " ++ name ++ ": " ++ s ++ "\n" ++ unparsed
+        Ok reparsedExp ->
+          -- Elm will crash first if Eval fails.
+          case Eval.run reparsedExp of
+            (val, widgets) -> "ok"
+
+testExample name code =
+  [ (\() -> testEvalsWithoutErrors name code)
+  , (\() -> testReparsedUnparsedEvalsWithoutErrors name code)
+  ]
+
+exampleTests : () -> List (() -> List (() -> String))
+exampleTests () =
+  List.map
+    (\(name, code, thunk) -> \() -> testExample name code)
+    Examples.list

--- a/tests/UnparserTests.elm
+++ b/tests/UnparserTests.elm
@@ -1,0 +1,83 @@
+module UnparserTests where
+
+import String
+
+import LangParser2
+import LangUnparser
+
+shouldEqual : a -> a -> String
+shouldEqual actual expected =
+  if actual == expected then
+    "ok"
+  else
+    "expected " ++ toString expected ++ "\nbut got  " ++ toString actual
+
+testParseUnparseMatch littleStr =
+  case LangParser2.parseE littleStr of
+    Err s ->
+      "can't parse: " ++ s ++ "\n" ++ littleStr
+    Ok parsed ->
+      let unparsed =
+        LangUnparser.unparse parsed
+      in
+      unparsed `shouldEqual` littleStr
+
+littlePrograms =
+  [ "5"
+  , "55"
+  , " 55"
+  , " 55{0-5.6}"
+  , "true"
+  , "  true"
+  , "false"
+  , "  false"
+  , "'string'"
+  , "  'string'"
+  , "variable"
+  , "  variable"
+  , "(\\_ 'exp')"
+  , " (\\ x 'exp'  )"
+  , "(\\( a b) 'exp')"
+  , " (\\[a b] 'exp'  )"
+  , "(func arg1 arg2)"
+  , " (func arg1 arg2  )"
+  , " (   (func arg1    ) arg2 arg3  )"
+  , "(pi)"
+  , "  (pi  )"
+  , "(sqrt 5.5)"
+  , "  (sqrt 5.5  )"
+  , "(+ 1 2 )"
+  , "  (+ 3 4  )"
+  , "[]"
+  , "  [ ]"
+  , "[ a ]"
+  , "[ a b c ]"
+  , "  [ a  b   ]"
+  , "[ a b   | []  ]"
+  , "[ a b   | c  ]"
+  , "[ a b   | [  c ]  ]"
+  , "[||]"
+  , "  [| |]"
+  , "[| 1 2 3 |]"
+  , "  [|   1 2  |]"
+  , "[| 1 2 6..8 |]"
+  , "  [| 1 2 6  ..   8 |]"
+  , "(if (= a b) 'body1' 'body2')"
+  , "   (if  (= a b )  'body1' 'body2'     )"
+  , "(case (+ 4 5) (1 'body1') ([h|tail] 'body2') (true 'body3') (var 'body4'))"
+  , "  (case (+ 4 5)\n   (1 'body1')\n   ([ h  | tail   ]\n   'body2') (  true\n   'body3')\n   (var 'body4')\n  )"
+  , "(let [a b] exp 'body')"
+  , "  (letrec [ a b ] exp\n'body'\n  )"
+  , "(def x 6) x"
+  , "(def [a b | t] exp) 'body'"
+  , "  (defrec a exp   ) 'body'"
+  , "  ; Comment\n\n'exp'"
+  , "# unannotated-numbers: n?\n'exp'"
+  , "  # unannotated-numbers:    n?\n\n  'exp'"
+  ]
+
+unparserTests : () -> List (() -> String)
+unparserTests () =
+  List.map
+    (\code -> \() -> testParseUnparseMatch code)
+    littlePrograms

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "elm-version": "0.16.0 <= v < 0.17.0",
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-svg": "2.0.1 <= v < 3.0.0",
+        "evancz/elm-html": "4.0.0 <= v < 5.0.0",
+        "evancz/virtual-dom": "2.0.0 <= v < 3.0.0",
+        "maxsnew/lazy": "1.0.1 <= v < 2.0.0",
+        "Apanatshka/elm-signal-extra": "5.7.0 <= v < 6.0.0"
+    }
+}

--- a/tests/refresh_elm-package.js
+++ b/tests/refresh_elm-package.js
@@ -1,0 +1,26 @@
+// The test elm-package.json needs to be nearly identical to
+// the main elm-package.json.
+
+// This script copies the main elm-package.json, adds the necessary
+// additions, then runs `elm-package` to prompt you for the
+// installation of any required packages.
+
+// Run like so:
+// $ node refresh_elm-package.js
+
+const fs = require("fs");
+const child_process = require("child_process");
+
+var main_elm_package_str = fs.readFileSync(__dirname + "/../src/elm-package.json", 'utf8');
+var elm_package_json     = JSON.parse(main_elm_package_str);
+
+// Tell Elm to look in /src for source files
+elm_package_json["source-directories"].push("../src");
+
+// elm_package_json["dependencies"]["laszlopandy/elm-console"] = "1.1.0 <= v < 2.0.0";
+
+var test_elm_package_str = JSON.stringify(elm_package_json, null, "    ");
+
+fs.writeFileSync(__dirname + "/elm-package.json", test_elm_package_str, 'utf8');
+
+child_process.spawnSync("elm-package", ["install"], {stdio: 'inherit'});

--- a/tests/support/runner.js
+++ b/tests/support/runner.js
@@ -16,7 +16,30 @@ with (global) {
 }
 
 
+function red(str) {
+  return "\x1b[31m" + str + "\x1b[0m";
+}
+
+// Apologies to the red/green colorblind.
+function green(str) {
+  return "\x1b[32m" + str + "\x1b[0m";
+}
+
+function yellow(str) {
+  return "\x1b[33m" + str + "\x1b[0m";
+}
+
+
 var testsToRun = [];
+var testNameFilter;
+
+if (process.env["SNS_TESTS_FILTER"]) {
+  testNameFilter = new RegExp(process.env["SNS_TESTS_FILTER"]);
+  console.log("Running " + yellow(testNameFilter.toString()) + " test functions. Unset SNS_TESTS_FILTER to run all tests.");
+} else {
+  testNameFilter = new RegExp();
+  console.log("Running all tests. Set SNS_TESTS_FILTER to filter tests by name.");
+}
 
 // Look for all SomethingTest(s) modules...
 for (moduleName in Elm) {
@@ -26,7 +49,9 @@ for (moduleName in Elm) {
     // Gather all test(s)/somethingTest(s)/something_test(s) functions in the module
     for (itemName in compiledModule) {
       var item = compiledModule[itemName];
-      if (itemName.match(/(^t|_t|T)ests?$/) && typeof item === "function") {
+      if (itemName.match(/(^t|_t|T)ests?$/) &&
+          itemName.match(testNameFilter)    &&
+          typeof item === "function") {
         testsToRun.push(item);
       }
     }
@@ -56,15 +81,6 @@ function arrayifyElmList(elmList) {
     head = head._1;
   }
   return list;
-}
-
-function red(str) {
-  return "\x1b[31m" + str + "\x1b[0m";
-}
-
-// Apologies to the red/green colorblind.
-function green(str) {
-  return "\x1b[32m" + str + "\x1b[0m";
 }
 
 function failTest(failureMessage) {

--- a/tests/support/runner.js
+++ b/tests/support/runner.js
@@ -1,0 +1,133 @@
+// This runner looks for and runs somethingTest functions in
+// TestSomething.elm files.
+//
+// Each somethingTest function can return either:
+// 1. a string ("ok" test result or a failure message), or
+// 2. more tests as a list of functions of () -> String
+//    (which in turn might return a string or a list)
+//
+// Invoke this runner with the ./test.sh script.
+
+const fs = require("fs");
+
+// Load the Elm program into our namespace.
+with (global) {
+  eval(fs.readFileSync(__dirname + "/../build/test.js", "utf8"));
+}
+
+
+var testsToRun = [];
+
+// Look for all SomethingTest(s) modules...
+for (moduleName in Elm) {
+  if (moduleName.match(/Tests?$/)) {
+    var compiledModule = Elm[moduleName].make(Elm);
+
+    // Gather all test(s)/somethingTest(s)/something_test(s) functions in the module
+    for (itemName in compiledModule) {
+      var item = compiledModule[itemName];
+      if (itemName.match(/(^t|_t|T)ests?$/) && typeof item === "function") {
+        testsToRun.push(item);
+      }
+    }
+  }
+}
+
+
+var passCount = 0;
+var failCount = 0;
+var failureMessages = [];
+
+// Input:
+// { ctor: '::',
+// _0: [Function],
+// _1:
+//  { ctor: '::',
+//    _0: [Function],
+//    _1: { ctor: '::', _0: [Function], _1: [Object] } } }
+//
+// Output:
+// [ [Function], [Function], ... ]
+function arrayifyElmList(elmList) {
+  var list = [];
+  var head = elmList;
+  while (head.ctor === "::") {
+    list.unshift(head._0);
+    head = head._1;
+  }
+  return list;
+}
+
+function red(str) {
+  return "\x1b[31m" + str + "\x1b[0m";
+}
+
+// Apologies to the red/green colorblind.
+function green(str) {
+  return "\x1b[32m" + str + "\x1b[0m";
+}
+
+function failTest(failureMessage) {
+  failCount++;
+  console._stdout.write(red("F"));
+  failureMessages.push(failureMessage);
+}
+
+while (testsToRun.length > 0) {
+
+  var test = testsToRun.shift();
+  var result = test();
+
+  if (typeof result === "string") {
+
+    // We have a test result!
+    if (result === "ok") {
+      passCount++;
+      console._stdout.write(green("."));
+    } else {
+      failTest(result);
+    }
+
+
+  } else if (result.ctor === "::" && typeof result._0 === "function") {
+
+    // We have a list of more tests to run!
+    var newTests = arrayifyElmList(result);
+    testsToRun = testsToRun.concat(newTests);
+
+  } else {
+
+    failTest("Test did not return a string or list of functions: " + test.toString());
+
+  }
+
+}
+
+// The .......FF.....F..F... stuff doesn't have a newline
+if (passCount + failCount > 0) {
+  console._stdout.write("\n");
+}
+
+// Output failure messages, if any.
+if (failCount > 0) {
+  console.error("");
+  for (i in failureMessages) {
+    console.error(red(failureMessages[i]));
+    console.error("");
+  }
+}
+
+// Summary goes to stdout if everything passes, otherwise to stderr.
+var report = (failCount === 0 ? console.log : console.error);
+
+report("" + (passCount + failCount) + " tests: " + passCount + " passed, " + failCount + " failed.");
+
+// Exit with non-success if any tests fail.
+if (failCount > 0) {
+  process.exit(1);
+} else if (passCount > 0) {
+  console.log(green(" ____   __    __  _  _  __   _ "));
+  console.log(green("(  _ \\ /  \\  /  \\( \\/ )/ _\\ / \\"));
+  console.log(green(" ) _ ((  O )(  O ))  //    \\\\_/"));
+  console.log(green("(____/ \\__/  \\__/(__/ \\_/\\_/(_)"));
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $FILE_DIR
+
+elm-make *Test*.elm --output build/test.js && node support/runner.js

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,4 +5,4 @@ FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $FILE_DIR
 
-elm-make *Test*.elm --output build/test.js && node support/runner.js
+/usr/bin/time sh -c 'elm-make *Test*.elm --output build/test.js && node support/runner.js'

--- a/watchmake
+++ b/watchmake
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Script to rebuild the project when a file changes.
+# Does not rebuild the built-in examples.
+#
+# Usage: ./watchmake
+#
+# Requires fs-watch. ($ brew install fswatch)
+# https://emcrisostomo.github.io/fswatch/getting.html
+
+FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $FILE_DIR
+
+# If you need to work on built-in examples, change to "make examples html"
+
+echo "fswatch -Ee 'git|build|Generated' . | xargs -ton 1 sh -c 'cd src; make html'"
+fswatch -Ee 'git|build|Generated' . | xargs -ton 1 sh -c 'cd src; make html'

--- a/watchtest
+++ b/watchtest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Script to rerun tests when a file changes.
+#
+# Usage: ./watchtest
+#
+# Requires fs-watch. ($ brew install fswatch)
+# https://emcrisostomo.github.io/fswatch/getting.html
+
+FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "fswatch -Ee 'git|build|Generated' . | xargs -ton 1 bash -c '$FILE_DIR/tests/test.sh'"
+fswatch -Ee 'git|build|Generated' . | xargs -ton 1 bash -c "$FILE_DIR/tests/test.sh"


### PR DESCRIPTION
This PR reworks whitespace handling to allow for cleaner program synthesis. An "it works!" version of constant dig is included.

A few functions were refactored along the way (e.g. `applySubst` has been rewritten to use `mapExp` and `substPlusOf_` to use `foldExp`) and some dead code is removed.

![dig_v0 1 1](https://cloud.githubusercontent.com/assets/506950/12833463/708a145a-cb66-11e5-82f5-ef27c9771bf0.gif)

The PR also includes a rudimentary test runner and some rudimentary tests.

The initial tests cover parse/unparse equivalence for all kinds of expressions as well as a "parse and run every example to make sure none of them crash" sanity test.

From the updated README:

## Running Tests

If you hack on Sketch-n-Sketch, there are some tests to run. Writing more tests is, of course, encouraged.

Run once:

```
$ ./tests/test.sh
```

Run when files change (requires [fswatch](https://emcrisostomo.github.io/fswatch/)):

```
$ ./watchtest
```

To run only tests with a certain string in their name, set `SNS_TESTS_FILTER `:

```
$ SNS_TESTS_FILTER =unparser ./watchtest
```

To write a new test, make a function of type `() -> String` named `somethingTest` in a `tests/myTests.elm` file. If the function returns the string `"ok"` it is considered a passing test, otherwise the returned string will be displayed as a failure message.

You can also return a list of test functions, `() -> List (() -> String)`, and each test will be run individually.

See [existing tests](https://github.com/ravichugh/sketch-n-sketch/tree/master/tests) for examples.

### Adding/Removing Elm Packages

If you add or remove a package from the project, the package list for the tests needs to be updated as well. Simply run `node tests/refresh_elm-packages.js` to copy over the main `elm-packages.json` into the tests directory.
