### PR TITLE
Simplify

### DIFF
--- a/ace-builds/src/mode-little.js
+++ b/ace-builds/src/mode-little.js
@@ -6,18 +6,18 @@ var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
 
 var LittleHighlightRules = function() {
     var builtinFunctions = "if|pi|cos|sin|arccos|arcsin|floor|ceiling|round|toStringid|always|compose|fst|len|map|map2|foldl|foldr|append|concat|concatMap|cartProd|zip|nil|cons|snoc|hd|tl|reverse|range|list0N|list1N|repeat|intermingle|mult|minus|div|neg|not|implies|clamp|joinStrings|concatStrings|spaces|delimit|parens|circle|ring|ellipse|rect|square|line|polygon|polyline|path|text|addAttr|rectCenter|square|squareCenter|circle_|ellipse_|rect_|square_|line_|polygon_|path_|updateCanvas|twoPi|halfPi|nPointsOnUnitCircle|nPointsOnCircle|nStar|zones|hideZonesTail|basicZonesTail|hSlider_|hSlider|button_|button|rotate";
-    
+
     // regexp must not have capturing parentheses. Use (?:) instead.
     // regexps are ordered -> the first match is used
 
-this.$rules = 
+this.$rules =
         {
     "start": [
         {
             token : "comment",
             regex : ";.*$"
         },
-        { 
+        {
             regex : /\(/,
             onMatch : function(value, state, stack) {
                 stack.push("start");
@@ -42,7 +42,7 @@ this.$rules =
         },
         {
             token : "variable",
-            regex : /\w+/
+            regex : /\w[\w']*/
         },
         {
             token : "string",
@@ -82,12 +82,12 @@ this.$rules =
         },
         {
             token : ["function.buildin.little", "text", "entity.name.function.little"],
-            regex: "(?:\\b(?:(" + builtinFunctions + "))\\b)(\\s+)((?:\\w)*)",
+            regex: "(?:\\b(?:(" + builtinFunctions + "))\\b)(\\s+)(\\w[\\w']*)?",
             next : "start"
         },
         {
             token : "function.little",
-            regex: /(?:\w+)/,
+            regex: /(?:\w[\w']*)/,
             next : "start"
         },
     ],
@@ -107,7 +107,7 @@ this.$rules =
         },
         {
             token : "variable.parameter",
-            regex : /\w+/,
+            regex : /\w[\w']*/,
             next  : "start"
         }
     ],
@@ -116,10 +116,10 @@ this.$rules =
             token : "paren.rparen",
             regex : /\)/,
             next : "start"
-        },  
+        },
         {
             token : "variable.parameter",
-            regex : /\w+/
+            regex : /\w[\w']*/
         }
     ],
     "pattern" : [
@@ -152,7 +152,7 @@ this.$rules =
         },
         {
             token : "variable.parameter",
-            regex : /\w+/,
+            regex : /\w[\w']*/,
             onMatch : function(value, state, stack) {
                 var lastPush = stack.pop();
                 if (lastPush == "startpat") {
@@ -174,7 +174,7 @@ this.$rules =
         {
             token : "string",
             regex : '[^\'\\\\]+'
-        }, 
+        },
         {
             token : "string",
             regex : '\'',
@@ -205,9 +205,9 @@ var Mode = function() {
 oop.inherits(Mode, TextMode);
 
 (function() {
-       
+
     this.lineCommentStart = ";";
-    
+
     this.$id = "ace/mode/little";
 }).call(Mode.prototype);
 

--- a/src/Eval.elm
+++ b/src/Eval.elm
@@ -146,6 +146,8 @@ eval env e =
           strPos e1.start ++
           "mutually recursive functions (i.e. letrec [...] [...] e) \
            not yet implemented"
+           -- Implementation also requires modifications to LangTransform.simply
+           -- so that clean up doesn't prune the funtions.
       _ ->
         errorMsg <| strPos e.start ++ "bad ELet"
 

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -3,6 +3,7 @@ module InterfaceController (upstate) where
 import Lang exposing (..) --For access to what makes up the Vals
 import LangParser2 exposing (parseE, freshen)
 import LangUnparser exposing (unparse, equationToLittle, preceedingWhitespace, addPreceedingWhitespace)
+import LangTransform
 import Sync
 import Eval
 import Utils
@@ -1359,7 +1360,7 @@ upstate evt old = case debugLog "Event" evt of
 -}
 
     CleanCode ->
-      let s' = unparse (cleanExp old.inputExp) in
+      let s' = unparse (LangTransform.simplify <| cleanExp old.inputExp) in
       let h' =
         if old.code == s'
           then old.history

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -1382,7 +1382,10 @@ upstate evt old = case debugLog "Event" evt of
               else addToHistory old.code old.history
           in
           let _ = debugLog "Cleaned: " code' in
-          { old | inputExp = cleanedExp, code = code', history = history' }
+          let newModel = { old | inputExp = cleanedExp, code = code', history = history' } in
+          case old.editingMode of
+            Nothing -> upstate Run newModel
+            _       -> newModel
 
     -- Elm does not have function equivalence/pattern matching, so we need to
     -- thread these events through upstate in order to catch them to rerender

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -1072,23 +1072,28 @@ upstate evt old = case debugLog "Event" evt of
           let featureNamesStr       = String.join " " nonCollidingFeatureNames in
           let featureExpressionsStr = String.join " " featureExpressionStrs in
           let includeFeatures       = (List.length featureNames) > 0 in
+          let letOrDef patsStr assignsStr body =
+              if isTopLevel deepestCommonScope old.inputExp then
+                "(def ["++patsStr++"] ["++assignsStr++"])"
+                ++ body
+              else
+                "(let ["++patsStr++"] ["++assignsStr++"]"
+                ++ body ++ ")"
+          in
           let originalsLet body =
             oldPreceedingWhitespace
-            ++ "(let ["++constantOrigNamesStr++"] ["++constantValuesStr++"]"
-            ++ body ++ ")"
+            ++ (letOrDef constantOrigNamesStr constantValuesStr body)
           in
           let tracesLet body =
             if includeFeatures then
               extraWhitespace ++ oldPreceedingWhitespace
-              ++ "(let ["++featureNamesStr++"] ["++featureExpressionsStr++"]"
-              ++ body ++ ")"
+              ++ (letOrDef featureNamesStr featureExpressionsStr body)
             else
               body
           in
           let primesLet body =
             extraWhitespace ++ oldPreceedingWhitespace
-            ++ "(let ["++constantPrimeNamesStr++"] ["++constantOrigNamesStr++"]"
-            ++ body ++ ")"
+            ++ (letOrDef constantPrimeNamesStr constantOrigNamesStr body)
           in
           originalsLet
           <| tracesLet

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -1403,6 +1403,7 @@ upstate evt old = case debugLog "Event" evt of
             reparsed
             |> cleanExp
             |> LangTransform.simplify
+            |> LangTransform.removeExtraPostfixes ["Orig", "'"]
             |> freshen
           in
           let code' = unparse cleanedExp in

--- a/src/InterfaceController.elm
+++ b/src/InterfaceController.elm
@@ -992,7 +992,7 @@ upstate evt old = case debugLog "Event" evt of
                 let scopesAndBaseIdent = String.join "_" (scopeNamesLiftedThrough ++ [baseIdent]) in
                 let baseIdentOrig  =
                   if scopesAndBaseIdent == baseIdent
-                  then baseIdent ++ "Orig"
+                  then baseIdent ++ "_orig"
                   else scopesAndBaseIdent
                 in
                 let baseIdentPrime = scopesAndBaseIdent ++ "'" in
@@ -1403,7 +1403,7 @@ upstate evt old = case debugLog "Event" evt of
             reparsed
             |> cleanExp
             |> LangTransform.simplify
-            |> LangTransform.removeExtraPostfixes ["Orig", "'"]
+            |> LangTransform.removeExtraPostfixes ["_orig", "'"]
             |> freshen
           in
           let code' = unparse cleanedExp in

--- a/src/InterfaceModel.elm
+++ b/src/InterfaceModel.elm
@@ -52,7 +52,7 @@ type alias Model =
   , midOffsetY : Int  -- extra codebox width in horizontal orientation
   , showZones : ShowZones
   , syncOptions : Sync.Options
-  , editingMode : Maybe Code -- Nothing is False
+  , editingMode : Maybe Code -- Nothing means not editing
                              -- Just s is True, where s is previous code
   , caption : Maybe Caption
   , showWidgets : Bool
@@ -183,6 +183,7 @@ type Event = CodeUpdate String -- TODO this doesn't help with anything
            --A state such that we're waiting for a response from Ace
            | WaitRun
            | WaitSave String
+           | WaitClean
            | WaitCodeBox
 
 events : Signal.Mailbox Event

--- a/src/InterfaceView2.elm
+++ b/src/InterfaceView2.elm
@@ -1716,7 +1716,7 @@ modeButton model =
 cleanButton model =
   let disabled = case model.mode of Live _ -> False
                                     _      -> True in
-  simpleEventButton_ disabled CleanCode "Clean" "Clean" "Clean Up"
+  simpleEventButton_ disabled WaitClean "Clean" "Clean" "Clean Up"
 
 orientationButton w h model =
     let text = "[Orientation] " ++ toString model.orient

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -559,6 +559,12 @@ identifiersSet exp =
   |> Set.fromList
 
 
+identifiersSetInPat : Pat -> Set.Set Ident
+identifiersSetInPat pat =
+  identifiersListInPat pat
+  |> Set.fromList
+
+
 identifiersList : Exp -> List Ident
 identifiersList exp =
   let folder e__ acc =

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -402,15 +402,16 @@ flattenExpTree exp =
   exp :: List.concatMap flattenExpTree (childExps exp)
 
 -- For each node for which `predicate` returns True, return it and its ancestors
+-- For each matching node, ancestors appear in order: root first, match last.
 findAllWithAncestors : (Exp -> Bool) -> Exp -> List (List Exp)
 findAllWithAncestors predicate exp =
-  findAllWithAncestorsRec predicate [] exp
+  findAllWithAncestors_ predicate [] exp
 
-findAllWithAncestorsRec : (Exp -> Bool) -> List Exp -> Exp -> List (List Exp)
-findAllWithAncestorsRec predicate ancestors exp =
+findAllWithAncestors_ : (Exp -> Bool) -> List Exp -> Exp -> List (List Exp)
+findAllWithAncestors_ predicate ancestors exp =
   let ancestorsAndThis = ancestors ++ [exp] in
   let thisResult       = if predicate exp then [ancestorsAndThis] else [] in
-  let recurse exp      = findAllWithAncestorsRec predicate ancestorsAndThis exp in
+  let recurse exp      = findAllWithAncestors_ predicate ancestorsAndThis exp in
   thisResult ++ List.concatMap recurse (childExps exp)
 
 childExps : Exp -> List Exp

--- a/src/Lang.elm
+++ b/src/Lang.elm
@@ -553,6 +553,22 @@ isScope maybeParent exp =
     Nothing -> isObviouslyScope
 
 
+-- Is the expression in the body of only defs/comments/options?
+--
+-- The "top level" is a single path on the tree, so walk it and look
+-- for the target expression.
+isTopLevel : Exp -> Exp -> Bool
+isTopLevel exp program =
+  if exp == program then
+    True
+  else
+    case program.val.e__ of
+      ELet _ Def _ _ _ body _ -> isTopLevel exp body
+      EComment _ _ e          -> isTopLevel exp e
+      EOption _ _ _ _ e       -> isTopLevel exp e
+      _                       -> False
+
+
 identifiersSet : Exp -> Set.Set Ident
 identifiersSet exp =
   identifiersList exp

--- a/src/LangParser2.elm
+++ b/src/LangParser2.elm
@@ -156,7 +156,7 @@ unwrapChars = List.map .val << .val
 isAlpha c        = Char.isLower c || Char.isUpper c
 isAlphaNumeric c = Char.isLower c || Char.isUpper c || Char.isDigit c
 isWhitespace c   = c == ' ' || c == '\n' || c == '\t'
-isIdentChar c    = isAlphaNumeric c || c == '_'
+isIdentChar c    = isAlphaNumeric c || c == '_' || c == '\''
 isDelimiter c    = String.any ((==) c) "[]{}()|"
 isSymbol c       = not (isAlphaNumeric c || isWhitespace c || isDelimiter c)
 

--- a/src/LangTransform.elm
+++ b/src/LangTransform.elm
@@ -1,0 +1,168 @@
+module LangTransform (simplify) where
+
+import Set
+
+import Lang exposing (..)
+import LangUnparser exposing (..)
+import Utils
+
+
+-- Removes unused variables
+-- Inlines variables assigned directly to another variable and not otherwise used
+simplify : Exp -> Exp
+simplify exp =
+  let simplified = exp |> inlineTrivialRenamings |> removeUnusedVars in
+  if simplified == exp then
+    exp
+  else
+    simplify simplified
+
+
+removeUnusedVars exp =
+  let remover e__ =
+    case e__ of
+      ELet ws1 letKind rec pat assign body ws2 ->
+        let usedNames = Lang.identifiersSet body in
+        let letRemoved =
+          let oldPreceedingWs = preceedingWhitespaceExp__ e__ in
+          (replacePreceedingWhitespace oldPreceedingWs body).val.e__
+        in
+        case (pat.val, assign.val.e__) of
+          -- Simple assignment.
+          (PVar _ ident _, _) ->
+            if Set.member ident usedNames then
+              e__
+            else
+              letRemoved
+
+          -- List assignment, no tail.
+          (PList pws1 pats pws2 Nothing pws3, EList aws1 assigns aws2 Nothing aws3) ->
+            let patsAssigns = Utils.zip pats assigns in
+            let usedPatsAssigns =
+              List.filter
+                  (\(pat, assign) ->
+                    case pat.val of
+                      PVar _ ident _ -> Set.member ident usedNames
+                      _              -> True
+                  )
+                  patsAssigns
+            in
+            case List.length usedPatsAssigns of
+              0 ->
+                letRemoved
+
+              1 ->
+                let (thePat, theAssign) = Utils.head_ usedPatsAssigns in
+                let newPat    = replacePreceedingWhitespacePat pws1 thePat in
+                let newAssign = replacePreceedingWhitespace aws1 theAssign in
+                ELet ws1 letKind rec newPat newAssign body ws2
+
+              _ ->
+                let newPat    = withDummyRange <| PList pws1 (List.map fst usedPatsAssigns) pws2 Nothing pws3 in
+                let newAssign = withDummyPos   <| EList aws1 (List.map snd usedPatsAssigns) aws2 Nothing aws3 in
+                ELet ws1 letKind rec newPat newAssign body ws2
+
+          _ ->
+            e__
+
+      _ ->
+        e__
+  in
+  mapExpViaExp__ remover exp
+
+
+-- Inline single-use variables that are merely assigned to another variable.
+inlineTrivialRenamings exp =
+  let inlineReplaceIfTrivialRename targetIdent newExp e__ =
+    case e__ of
+      ELet ws1 letKind rec pat assign body ws2 ->
+        case (pat.val, assign.val.e__) of
+          -- Simple assignment.
+          (PVar _ _ _, EVar oldWs assignIdent) ->
+            if assignIdent == targetIdent then
+              let newExpAdjustedWs = replacePreceedingWhitespace oldWs newExp in
+              ELet ws1 letKind rec pat newExpAdjustedWs body ws2
+            else
+              e__
+
+          -- List assignment, no tail.
+          (PList _ _ _ Nothing _, EList aws1 assigns aws2 Nothing aws3) ->
+            let newAssigns =
+              List.map
+                  (\assignExp ->
+                    case assignExp.val.e__ of
+                      EVar _ assignIdent ->
+                        if assignIdent == targetIdent then
+                          let oldPreceedingWs = preceedingWhitespace assignExp in
+                          replacePreceedingWhitespace oldPreceedingWs newExp
+                        else
+                          assignExp
+
+                      _ ->
+                        assignExp
+                  )
+                  assigns
+            in
+            let newAssignsListExp =
+              withDummyPos <| EList aws1 newAssigns aws2 Nothing aws3
+            in
+            ELet ws1 letKind rec pat newAssignsListExp body ws2
+
+          _ ->
+            e__
+
+      _ ->
+        e__
+  in
+  let inliner e__ =
+    case e__ of
+      ELet ws1 letKind rec pat assign body ws2 ->
+        let identsAndAssigns =
+          case (pat.val, assign.val.e__) of
+            -- Simple assignment.
+            (PVar _ ident _, _) ->
+              [(ident, assign)]
+
+            -- List assignment, no tail.
+            (PList pws1 pats pws2 Nothing pws3, EList aws1 assigns aws2 Nothing aws3) ->
+              let patsAssigns = Utils.zip pats assigns in
+              let simplePatsAssigns =
+                List.filterMap
+                    (\(pat, assign) ->
+                      case pat.val of
+                        PVar _ ident _ -> Just (ident, assign)
+                        _              -> Nothing
+                    )
+                    patsAssigns
+              in
+              simplePatsAssigns
+
+            _ ->
+              []
+        in
+        let nameCounts = Lang.identifierCounts body in
+        let letRemoved newBody =
+          let oldPreceedingWs = preceedingWhitespaceExp__ e__ in
+          (replacePreceedingWhitespace oldPreceedingWs newBody).val.e__
+        in
+        let identsAndAssignsInliningCandidates =
+          List.filter
+              (\(ident, assign) ->
+                1 == (Utils.getWithDefault ident 0 nameCounts)
+              )
+              identsAndAssigns
+        in
+        let newBody =
+          List.foldl
+              (\(ident, assign) resultExp ->
+                mapExpViaExp__ (inlineReplaceIfTrivialRename ident assign) resultExp
+              )
+              body
+              identsAndAssignsInliningCandidates
+        in
+        ELet ws1 letKind rec pat assign newBody ws2
+
+      _ ->
+        e__
+  in
+  mapExpViaExp__ inliner exp

--- a/src/LangTransform.elm
+++ b/src/LangTransform.elm
@@ -79,8 +79,7 @@ removeUnusedVars exp =
       ELet ws1 letKind rec pat assign body ws2 ->
         let usedNames = Lang.identifiersSet body in
         let letRemoved =
-          let oldPreceedingWs = preceedingWhitespaceExp__ e__ in
-          (replacePreceedingWhitespace oldPreceedingWs body).val.e__
+          body.val.e__
         in
         case (pat.val, assign.val.e__) of
           -- Simple assignment.
@@ -111,8 +110,8 @@ removeUnusedVars exp =
 
                 1 ->
                   let (thePat, theAssign) = Utils.head_ usedPatsAssigns in
-                  let newPat    = replacePreceedingWhitespacePat pws1 thePat in
-                  let newAssign = replacePreceedingWhitespace aws1 theAssign in
+                  let newPat    = replacePrecedingWhitespacePat pws1 thePat in
+                  let newAssign = replacePrecedingWhitespace aws1 theAssign in
                   ELet ws1 letKind rec newPat newAssign body ws2
 
                 _ ->
@@ -162,7 +161,7 @@ inlineTrivialRenamings exp =
           -- Simple assignment.
           (PVar _ _ _, EVar oldWs assignIdent) ->
             if assignIdent == targetIdent then
-              let newExpAdjustedWs = replacePreceedingWhitespace oldWs newExp in
+              let newExpAdjustedWs = replacePrecedingWhitespace oldWs newExp in
               ELet ws1 letKind rec pat newExpAdjustedWs body ws2
             else
               e__
@@ -175,8 +174,8 @@ inlineTrivialRenamings exp =
                     case assignExp.val.e__ of
                       EVar _ assignIdent ->
                         if assignIdent == targetIdent then
-                          let oldPreceedingWs = preceedingWhitespace assignExp in
-                          replacePreceedingWhitespace oldPreceedingWs newExp
+                          let oldPrecedingWs = precedingWhitespace assignExp in
+                          replacePrecedingWhitespace oldPrecedingWs newExp
                         else
                           assignExp
 
@@ -201,8 +200,8 @@ inlineTrivialRenamings exp =
       ELet ws1 letKind rec pat assign body ws2 ->
         let nameCounts = Lang.identifierCounts body in
         let letRemoved newBody =
-          let oldPreceedingWs = preceedingWhitespaceExp__ e__ in
-          (replacePreceedingWhitespace oldPreceedingWs newBody).val.e__
+          let oldPrecedingWs = precedingWhitespaceExp__ e__ in
+          (replacePrecedingWhitespace oldPrecedingWs newBody).val.e__
         in
         let identsAndAssignsInliningCandidates =
           List.filter

--- a/src/LangUnparser.elm
+++ b/src/LangUnparser.elm
@@ -196,7 +196,8 @@ equationToLittle substStr eqn =
           else
             -- Constants introduced by the equation (e.g. /2 for midpoint) won't
             -- have a value in subst.
-            toString n
+            -- Also, they should be frozen.
+            toString n ++ "!"
 
         _ ->
           "?"

--- a/src/LangUnparser.elm
+++ b/src/LangUnparser.elm
@@ -1,7 +1,7 @@
 module LangUnparser
-  (unparse, equationToLittle, bumpCol, incCol, preceedingWhitespace,
-    preceedingWhitespaceExp__, addPreceedingWhitespace,
-    replacePreceedingWhitespace, replacePreceedingWhitespacePat) where
+  (unparse, equationToLittle, bumpCol, incCol, precedingWhitespace,
+    precedingWhitespaceExp__, addPrecedingWhitespace,
+    replacePrecedingWhitespace, replacePrecedingWhitespacePat) where
 
 import Lang exposing (..)
 import OurParser2 exposing (Pos, WithPos, WithInfo, startPos)
@@ -26,13 +26,13 @@ incCol = bumpCol 1
 ------------------------------------------------------------------------------
 
 
-preceedingWhitespace : Exp -> String
-preceedingWhitespace exp =
-  preceedingWhitespaceExp__ exp.val.e__
+precedingWhitespace : Exp -> String
+precedingWhitespace exp =
+  precedingWhitespaceExp__ exp.val.e__
 
 
-preceedingWhitespacePat : Pat -> String
-preceedingWhitespacePat pat =
+precedingWhitespacePat : Pat -> String
+precedingWhitespacePat pat =
   case pat.val of
     PVar   ws ident wd         -> ws
     PConst ws n                -> ws
@@ -40,8 +40,8 @@ preceedingWhitespacePat pat =
     PList  ws1 es ws2 rest ws3 -> ws1
 
 
-preceedingWhitespaceExp__ : Exp__ -> String
-preceedingWhitespaceExp__ e__ =
+precedingWhitespaceExp__ : Exp__ -> String
+precedingWhitespaceExp__ e__ =
   case e__ of
     EBase    ws v                     -> ws
     EConst   ws n l wd                -> ws
@@ -58,23 +58,23 @@ preceedingWhitespaceExp__ e__ =
     EOption  ws1 s1 ws2 s2 e1         -> ws1
 
 
-addPreceedingWhitespace : String -> Exp -> Exp
-addPreceedingWhitespace newWs exp =
-  mapPreceedingWhitespace (\oldWs -> oldWs ++ newWs) exp
+addPrecedingWhitespace : String -> Exp -> Exp
+addPrecedingWhitespace newWs exp =
+  mapPrecedingWhitespace (\oldWs -> oldWs ++ newWs) exp
 
 
-replacePreceedingWhitespace : String -> Exp -> Exp
-replacePreceedingWhitespace newWs exp =
-  mapPreceedingWhitespace (\oldWs -> newWs) exp
+replacePrecedingWhitespace : String -> Exp -> Exp
+replacePrecedingWhitespace newWs exp =
+  mapPrecedingWhitespace (\oldWs -> newWs) exp
 
 
-replacePreceedingWhitespacePat : String -> Pat -> Pat
-replacePreceedingWhitespacePat newWs pat =
-  mapPreceedingWhitespacePat (\oldWs -> newWs) pat
+replacePrecedingWhitespacePat : String -> Pat -> Pat
+replacePrecedingWhitespacePat newWs pat =
+  mapPrecedingWhitespacePat (\oldWs -> newWs) pat
 
 
-mapPreceedingWhitespace : (String -> String) -> Exp -> Exp
-mapPreceedingWhitespace mapWs exp =
+mapPrecedingWhitespace : (String -> String) -> Exp -> Exp
+mapPrecedingWhitespace mapWs exp =
   let e__' =
     case exp.val.e__ of
       EBase    ws v                     -> EBase    (mapWs ws) v
@@ -95,8 +95,8 @@ mapPreceedingWhitespace mapWs exp =
   { exp | val = { val | e__ = e__' } }
 
 
-mapPreceedingWhitespacePat : (String -> String) -> Pat -> Pat
-mapPreceedingWhitespacePat mapWs pat =
+mapPrecedingWhitespacePat : (String -> String) -> Pat -> Pat
+mapPrecedingWhitespacePat mapWs pat =
   let pat_' =
     case pat.val of
       PVar   ws ident wd         -> PVar   (mapWs ws) ident wd

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -87,6 +87,8 @@ port aceInTheHole =
               -- 'poke' Ace, rerendering if necessary
               Model.WaitRun -> True
               Model.WaitSave _ -> True
+              Model.WaitClean -> True
+              Model.MultiEvent [ _, Model.CleanCode ] -> True
               Model.WaitCodeBox -> True
               Model.MousePos _ -> True
 --              Model.KeysDown _ -> False
@@ -119,6 +121,7 @@ port aceInTheHole =
     in
         Signal.map fst
                       <| Signal.foldp packageModel initAceCodeBoxInfo
+                      -- <| Signal.map (\(m, e) -> let _ = Debug.log "Ace Event:" e in (m,e))
                       <| Signal.filter
                             (\a -> (not (fst a).basicCodeBox
                                     || snd a == Model.ToggleBasicCodeBox

--- a/src/Native/codeBox.js
+++ b/src/Native/codeBox.js
@@ -122,9 +122,10 @@ window.initializers.push(function (elmRuntime) {
       } else if (codeBoxInfo.kind == "runRequest") {
           //Same as above
           sendState("runResponse");
+      } else if (codeBoxInfo.kind == "cleanRequest") {
+        sendState("cleanResponse");
       } else if (codeBoxInfo.kind == "codeRequest") {
-          //Similiartly as above
-          sendState("codeResponse");
+        sendState("codeResponse");
       } else { //We don't recognize the request; log and do nothing
           console.log("codeBoxInfo type " + codeBoxInfo.kind + " unrecognized.");
       }

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -216,6 +216,11 @@ justGet k d = fromJust_ "Utils.justGet" <| Dict.get k d
 
 justGet_ s k d = fromJust_ ("Utils.justGet " ++ s) <| Dict.get k d
 
+getWithDefault key default dict =
+  case Dict.get key dict of
+    Just val -> val
+    Nothing -> default
+
 head_ = fromJust_ "Utils.head_" << List.head
 tail_ = fromJust_ "Utils.tail_" << List.tail
 last_ = head_ << List.reverse

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -158,6 +158,10 @@ maybeRemoveFirst x ys = case ys of
              Nothing      -> Nothing
              Just (b', l) -> Just (b', (a,b) :: l)
 
+removeLastElement : List a -> List a
+removeLastElement list =
+  List.take ((List.length list)-1) list
+
 adjacentPairs : Bool -> List a -> List (a, a)
 adjacentPairs includeLast list = case list of
   [] -> []

--- a/tests/Helpers/Matchers.elm
+++ b/tests/Helpers/Matchers.elm
@@ -1,0 +1,9 @@
+module Helpers.Matchers where
+
+
+shouldEqual : a -> a -> String
+shouldEqual actual expected =
+  if actual == expected then
+    "ok"
+  else
+    "expected " ++ toString expected ++ "\nbut got  " ++ toString actual

--- a/tests/Helpers/TestTemplates.elm
+++ b/tests/Helpers/TestTemplates.elm
@@ -1,0 +1,20 @@
+module Helpers.TestTemplates where
+
+import Helpers.Matchers exposing (..)
+import Helpers.Utils exposing (..)
+
+import LangParser2
+import LangUnparser
+import Lang
+
+
+testCodeTransform : (Lang.Exp -> Lang.Exp) -> String -> String -> String
+testCodeTransform transformer inputCode expectedOutputCode =
+  case LangParser2.parseE inputCode of
+    Err s ->
+      "can't parse: " ++ s ++ "\n" ++ inputCode
+
+    Ok inputExp ->
+      let transformedExp  = transformer inputExp in
+      let transformedCode = LangUnparser.unparse transformedExp in
+      (squish transformedCode) `shouldEqual` (squish expectedOutputCode)

--- a/tests/Helpers/Utils.elm
+++ b/tests/Helpers/Utils.elm
@@ -1,0 +1,8 @@
+module Helpers.Utils where
+
+import Regex
+
+-- Replace all runs of whitespace with a single space
+squish : String -> String
+squish str =
+  Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> " ") str

--- a/tests/Helpers/Utils.elm
+++ b/tests/Helpers/Utils.elm
@@ -1,8 +1,10 @@
 module Helpers.Utils where
 
 import Regex
+import String
 
 -- Replace all runs of whitespace with a single space
 squish : String -> String
 squish str =
-  Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> " ") str
+  String.trim <|
+    Regex.replace Regex.All (Regex.regex "\\s+") (\_ -> " ") str

--- a/tests/RemoveExtraPostfixesTests.elm
+++ b/tests/RemoveExtraPostfixesTests.elm
@@ -1,0 +1,27 @@
+module RemoveExtraPostfixesTests where
+
+import Helpers.TestTemplates exposing (..)
+
+import LangTransform
+
+
+testPostfixRemoval inputCode expectedOutputCode =
+  Helpers.TestTemplates.testCodeTransform
+    (LangTransform.removeExtraPostfixes ["Orig", "'"])
+    inputCode
+    expectedOutputCode
+
+
+testNoChange inputCode =
+  testPostfixRemoval inputCode inputCode
+
+
+removeExtraPostfixesTests () =
+  [ \() -> testNoChange       "(let x      6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x'     6 (+ x' x'))"          "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let xOrig  6 (+ xOrig xOrig))"    "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let xOrig' 6 (+ xOrig' xOrig'))"  "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x'Orig 6 (+ x'Orig x'Orig))"  "(let x 6 (+ x x))"
+  , \() -> testNoChange       "(let x' 6 (let x  7 (+ x x)))"
+  , \() -> testNoChange       "(let x  6 (let x' 7 (+ x' x')))"
+  ]

--- a/tests/RemoveExtraPostfixesTests.elm
+++ b/tests/RemoveExtraPostfixesTests.elm
@@ -7,7 +7,7 @@ import LangTransform
 
 testPostfixRemoval inputCode expectedOutputCode =
   Helpers.TestTemplates.testCodeTransform
-    (LangTransform.removeExtraPostfixes ["Orig", "'"])
+    (LangTransform.removeExtraPostfixes ["_orig", "'"])
     inputCode
     expectedOutputCode
 
@@ -17,11 +17,11 @@ testNoChange inputCode =
 
 
 removeExtraPostfixesTests () =
-  [ \() -> testNoChange       "(let x      6 (+ x x))"
-  , \() -> testPostfixRemoval "(let x'     6 (+ x' x'))"          "(let x 6 (+ x x))"
-  , \() -> testPostfixRemoval "(let xOrig  6 (+ xOrig xOrig))"    "(let x 6 (+ x x))"
-  , \() -> testPostfixRemoval "(let xOrig' 6 (+ xOrig' xOrig'))"  "(let x 6 (+ x x))"
-  , \() -> testPostfixRemoval "(let x'Orig 6 (+ x'Orig x'Orig))"  "(let x 6 (+ x x))"
-  , \() -> testNoChange       "(let x' 6 (let x  7 (+ x x)))"
-  , \() -> testNoChange       "(let x  6 (let x' 7 (+ x' x')))"
+  [ \() -> testNoChange       "(let x       6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x'      6 (+ x' x'))"            "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x_orig  6 (+ x_orig x_orig))"    "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x_orig' 6 (+ x_orig' x_orig'))"  "(let x 6 (+ x x))"
+  , \() -> testPostfixRemoval "(let x'_orig 6 (+ x'_orig x'_orig))"  "(let x 6 (+ x x))"
+  , \() -> testNoChange       "(let x'      6 (let x  7 (+ x x)))"
+  , \() -> testNoChange       "(let x       6 (let x' 7 (+ x' x')))"
   ]

--- a/tests/SimplifyTests.elm
+++ b/tests/SimplifyTests.elm
@@ -1,0 +1,55 @@
+module SimplifyTests where
+
+import Helpers.Matchers exposing (..)
+import Helpers.Utils exposing (..)
+
+import String
+
+import LangTransform
+import LangParser2
+import LangUnparser
+
+testSimplification inputCode expectedSimplification =
+  case LangParser2.parseE inputCode of
+    Err s ->
+      "can't parse: " ++ s ++ "\n" ++ inputCode
+
+    Ok inputExp ->
+      let simplifiedExp  = LangTransform.simplify inputExp in
+      let simplifiedCode = LangUnparser.unparse simplifiedExp in
+      (squish simplifiedCode) `shouldEqual` (squish expectedSimplification)
+
+
+testNoSimplification inputCode =
+  testSimplification inputCode inputCode
+
+
+unusedSimpleAssignmentTest () = testSimplification   "(let dead 6 'body')"   "'body'"
+usedSimpleAssignmentTest   () = testNoSimplification "(let alive 6 alive)"
+
+
+multipleAssignmentTests () =
+  [ \() -> testSimplification   "(let [dead1  dead2  dead3]  [6 7 8] 'body')"                 "'body'"
+  , \() -> testSimplification   "(let [alive1 dead2  dead3]  [6 7 8] alive1)"                 "(let alive1          6     alive1)"
+  , \() -> testSimplification   "(let [alive1 dead2  alive3] [6 7 8] [alive1 alive3])"        "(let [alive1 alive3] [6 8] [alive1 alive3])"
+  , \() -> testNoSimplification "(let [alive1 alive2 alive3] [6 7 8] [alive1 alive2 alive3])"
+  ]
+
+
+-- mapExp runs bottom-up so this magically works
+unusedVariableChainTest () =
+  testSimplification "(let dead1 6 (let dead2 dead1 'body'))"  "'body'"
+
+
+simpleAssignmentChainTests () =
+  [ \() -> testSimplification "(let redundant 6 (let alive           redundant     alive))"              "(let alive           6     alive)"
+  , \() -> testSimplification "(let redundant 6 (let [alive1 alive2] [redundant 7] (+ alive1 alive2)))"  "(let [alive1 alive2] [6 7] (+ alive1 alive2))"
+  ]
+
+usedVariableChainTest () =
+  testNoSimplification "(let alive1 6 (let alive2 alive1 (+ alive1 alive2)))"
+
+
+shadowedAssignmentChainTest () =
+  testSimplification "(let shadow 6 (let shadow 7 (let alive shadow alive)))"  "(let alive 7 alive)"
+

--- a/tests/SimplifyTests.elm
+++ b/tests/SimplifyTests.elm
@@ -33,10 +33,11 @@ multipleAssignmentTests () =
   , \() -> testSimplification   "(let [alive1 dead2  dead3]  [6 7 8] alive1)"                 "(let alive1          6     alive1)"
   , \() -> testSimplification   "(let [alive1 dead2  alive3] [6 7 8] [alive1 alive3])"        "(let [alive1 alive3] [6 8] [alive1 alive3])"
   , \() -> testNoSimplification "(let [alive1 alive2 alive3] [6 7 8] [alive1 alive2 alive3])"
+  , \() -> testNoSimplification "(let [alive mistake] [6] [mistake])"
   ]
 
 
--- mapExp runs bottom-up so this magically works
+-- mapExp runs bottom-up so this magically works.
 unusedVariableChainTest () =
   testSimplification "(let dead1 6 (let dead2 dead1 'body'))"  "'body'"
 
@@ -46,10 +47,40 @@ simpleAssignmentChainTests () =
   , \() -> testSimplification "(let redundant 6 (let [alive1 alive2] [redundant 7] (+ alive1 alive2)))"  "(let [alive1 alive2] [6 7] (+ alive1 alive2))"
   ]
 
-usedVariableChainTest () =
-  testNoSimplification "(let alive1 6 (let alive2 alive1 (+ alive1 alive2)))"
-
 
 shadowedAssignmentChainTest () =
   testSimplification "(let shadow 6 (let shadow 7 (let alive shadow alive)))"  "(let alive 7 alive)"
+
+
+-- More shadow testing.
+scopeHandlingTests () =
+  [ \() -> testNoSimplification "(let name1 5 (let name2 name1 (let name1 6 (+ name1 name2))))"
+  , \() -> testNoSimplification "(let name1 5 (let name2 name1 (let name2 6 (+ name1 name2))))"
+  , \() -> testNoSimplification "(let name1 5 (let name2 name1 (\\name1 [name1 name2])))"
+  , \() -> testNoSimplification "(let name1 5 (let name2 name1 (\\name2 [name1 name2])))"
+  , \() -> testNoSimplification "(let name1 5 (let name2 name1 (case 6 (name1 [name1 name2]) (name2 [name1 name2]))))"
+  ]
+
+
+-- Same shadow trickiness as scopes above, but in the assigns expressions.
+letrecScopeTests () =
+  [ \() -> testNoSimplification "(let name1 5 (let name2 name1 (letrec name1 (\\() [name1 name2]) [name1 name2])))"
+  , \() -> testNoSimplification "(let name1 5 (let name2 name1 (letrec name2 (\\() [name1 name2]) [name1 name2])))"
+  , \() -> testSimplification   "(let name1 5 (let name2 name1 (let    name1 (\\() [name1 name2]) [name1 name2])))"
+                                "(let name1 5 (let name2 name1 (let    name1 (\\() [name1 name1]) [name1 name2])))"
+  ]
+
+
+multiuseTest () =
+  testNoSimplification "(let alive 6 (let [renamed dummy] [alive (+ 6 alive)]) [renamed dummy])"
+
+
+doublyNamedValueTest () =
+  testSimplification "(let name1 6 (let name2 name1 (+ name1 name2)))"  "(let name1 6 (+ name1 name1))"
+
+
+doublyNamedValueInMultipleAssignmentsTest () =
+  testSimplification
+    "(let [name1 dummy1] [6 7] (let [name2 dummy2] [name1 9] [name1 name2 dummy1 dummy2]))"
+    "(let [name1 dummy1] [6 7] (let dummy2 9 [name1 name1 dummy1 dummy2]))"
 

--- a/tests/SimplifyTests.elm
+++ b/tests/SimplifyTests.elm
@@ -1,23 +1,15 @@
 module SimplifyTests where
 
-import Helpers.Matchers exposing (..)
-import Helpers.Utils exposing (..)
-
-import String
+import Helpers.TestTemplates exposing (..)
 
 import LangTransform
-import LangParser2
-import LangUnparser
+
 
 testSimplification inputCode expectedSimplification =
-  case LangParser2.parseE inputCode of
-    Err s ->
-      "can't parse: " ++ s ++ "\n" ++ inputCode
-
-    Ok inputExp ->
-      let simplifiedExp  = LangTransform.simplify inputExp in
-      let simplifiedCode = LangUnparser.unparse simplifiedExp in
-      (squish simplifiedCode) `shouldEqual` (squish expectedSimplification)
+  Helpers.TestTemplates.testCodeTransform
+    LangTransform.simplify
+    inputCode
+    expectedSimplification
 
 
 testNoSimplification inputCode =

--- a/tests/UnparserTests.elm
+++ b/tests/UnparserTests.elm
@@ -1,16 +1,11 @@
 module UnparserTests where
 
+import Helpers.Matchers exposing (..)
+
 import String
 
 import LangParser2
 import LangUnparser
-
-shouldEqual : a -> a -> String
-shouldEqual actual expected =
-  if actual == expected then
-    "ok"
-  else
-    "expected " ++ toString expected ++ "\nbut got  " ++ toString actual
 
 testParseUnparseMatch littleStr =
   case LangParser2.parseE littleStr of

--- a/tests/support/runner.js
+++ b/tests/support/runner.js
@@ -34,8 +34,8 @@ var testsToRun = [];
 var testNameFilter;
 
 if (process.env["SNS_TESTS_FILTER"]) {
-  testNameFilter = new RegExp(process.env["SNS_TESTS_FILTER"]);
-  console.log("Running " + yellow(testNameFilter.toString()) + " test functions. Unset SNS_TESTS_FILTER to run all tests.");
+  testNameFilter = new RegExp(process.env["SNS_TESTS_FILTER"], "i");
+  console.log("Running " + yellow(testNameFilter.toString()) + " tests. Unset SNS_TESTS_FILTER to run all tests.");
 } else {
   testNameFilter = new RegExp();
   console.log("Running all tests. Set SNS_TESTS_FILTER to filter tests by name.");
@@ -50,7 +50,7 @@ for (moduleName in Elm) {
     for (itemName in compiledModule) {
       var item = compiledModule[itemName];
       if (itemName.match(/(^t|_t|T)ests?$/) &&
-          itemName.match(testNameFilter)    &&
+          (itemName.match(testNameFilter) || moduleName.match(testNameFilter)) &&
           typeof item === "function") {
         testsToRun.push(item);
       }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,4 +5,4 @@ FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $FILE_DIR
 
-/usr/bin/time sh -c 'elm-make *Test*.elm --output build/test.js && node support/runner.js'
+/usr/bin/time sh -c 'elm-make *Test*.elm --output build/test.js && node --stack_size=2048 support/runner.js'

--- a/watchmake
+++ b/watchmake
@@ -14,5 +14,5 @@ cd $FILE_DIR
 
 # If you need to work on built-in examples, change to "make examples html"
 
-echo "fswatch -Ee 'git|build|Generated' . | xargs -ton 1 sh -c 'cd src; make html'"
-fswatch -Ee 'git|build|Generated' . | xargs -ton 1 sh -c 'cd src; make html'
+echo "fswatch -Ee 'git|build/|elm-stuff/|Generated' . | xargs -ton 1 sh -c 'cd src; make html'"
+fswatch -Ee 'git|build/|elm-stuff/|Generated' . | xargs -ton 1 sh -c 'cd src; make html'


### PR DESCRIPTION
"Clean Up" now:

- removes dead variables
- renames variables "simple" renamings
- renames variables with extra postfixes

"Dig" now:

- Creates `def`s instead of `let`s if at the top level
- Uses `'` instead of `Prime` for variable names
- If a constant is lifted out through multiple scopes, adds the scopes to the new lifted variable name
- Avoids appending `_orig` if the lifted variable name is unique (due to above)
- Shape feature has the common scopes across all its constants prepended to its variable name
- Limits preceding whitespace to at most 1 newline

Final result for SnS logo now looks like:

![screen shot 2016-02-26 at 8 27 46 pm](https://cloud.githubusercontent.com/assets/506950/13370231/a74f3232-dcc7-11e5-9dab-e2943a349149.png)
