### PR TITLE
Add new file template categories

### DIFF
--- a/src/ExamplesGenerated.elm
+++ b/src/ExamplesGenerated.elm
@@ -1,4 +1,4 @@
-module ExamplesGenerated exposing (list)
+module ExamplesGenerated exposing (list, templateCategories)
 
 import Lang
 import LangParser2 as Parser
@@ -8,6 +8,8 @@ import Utils
 import PreludeGenerated as Prelude
 import LangSvg
 import DefaultIconTheme
+
+fst (a, _) = a
 
 makeExample name s =
   let thunk () =
@@ -5141,6 +5143,151 @@ calendarIcon =
 """
 
 
+generalCategory =
+  ( "General"
+  , [ makeExample "BLANK" blank
+    , makeExample "*Prelude*" Prelude.src
+    ]
+  )
+
+defaultIconCategory =
+  ( "Default Icons"
+  , [ makeExample "Icon: Cursor" DefaultIconTheme.cursor
+    , makeExample "Icon: Text" DefaultIconTheme.text
+    , makeExample "Icon: Line" DefaultIconTheme.line
+    , makeExample "Icon: Rect" DefaultIconTheme.rect
+    , makeExample "Icon: Ellipse" DefaultIconTheme.ellipse
+    , makeExample "Icon: Polygon" DefaultIconTheme.polygon
+    , makeExample "Icon: Path" DefaultIconTheme.path
+    ]
+  )
+
+logoCategory =
+  ( "Logos"
+  , List.sortBy fst
+      [ makeExample "SnS Logo (UIST)" sns_UIST
+      , makeExample "SnS Logo Revisited (UIST)" sns_revisited_UIST
+      , makeExample "Botanic Garden Logo (UIST)" botanic_UIST
+      , makeExample "Logo" logo
+      , makeExample "Botanic Garden Logo" botanic
+      , makeExample "Active Trans Logo" activeTrans2
+      , makeExample "SnS Logo Wheel" snsLogoWheel
+      , makeExample "Haskell.org Logo" haskell
+      , makeExample "Cover Logo" cover
+      , makeExample "POP-PL Logo" poppl
+      , makeExample "Floral Logo 1" floralLogo
+      , makeExample "Floral Logo 2" floralLogo2
+      , makeExample "Elm Logo" elmLogo
+      , makeExample "Logo 2" logo2
+      , makeExample "Logo Sizes" logoSizes
+      ]
+  )
+
+flagCategory =
+  ( "Flags"
+  , List.sortBy fst
+      [ makeExample "Chicago Flag" chicago
+      , makeExample "US-13 Flag" usFlag13
+      , makeExample "US-50 Flag" usFlag50
+      , makeExample "French Sudan Flag" frenchSudan
+      ]
+  )
+
+
+otherCategory =
+  ( "Other"
+  , [ makeExample "Coffee Mugs (UIST)" coffee_UIST
+
+    , makeExample "Wave Boxes" sineWaveOfBoxes
+    , makeExample "Wave Boxes Grid" sineWaveGrid
+
+    , makeExample "Basic Slides" basicSlides
+    , makeExample "Sailboat" sailBoat
+    , makeExample "Sliders" sliders
+    , makeExample "Buttons" buttons
+    , makeExample "Widgets" widgets
+    , makeExample "xySlider" xySlider
+    , makeExample "Offsets" offsets
+    , makeExample "Tile Pattern" boxGridTokenFilter
+    , makeExample "Color Picker" rgba
+    , makeExample "Ferris Wheel" ferris
+    , makeExample "Ferris Task Before" ferris2
+    , makeExample "Ferris Task After" ferris2target
+    , makeExample "Ferris Wheel Slideshow" ferrisWheelSlideshow
+    , makeExample "Survey Results" surveyResultsTriHist2
+    , makeExample "Hilbert Curve Animation" hilbertCurveAnimation
+    , makeExample "Bar Graph" barGraph
+    , makeExample "Pie Chart" pieChart1
+    , makeExample "Solar System" solarSystem
+    , makeExample "Clique" clique
+    , makeExample "Eye Icon" eyeIcon
+    , makeExample "Horror Films" horrorFilms0
+    , makeExample "Cycling Association" cyclingAssociation0
+    , makeExample "Lillicon P" lilliconP
+    , makeExample "Lillicon P, v2" lilliconP2
+    , makeExample "Keyboard" keyboard
+    , makeExample "Keyboard Task Before" keyboard2
+    , makeExample "Keyboard Task After" keyboard2target
+    , makeExample "Tessellation Task Before" tessellation
+    , makeExample "Tessellation Task After" tessellationTarget
+    , makeExample "Tessellation 2" tessellation2
+    , makeExample "Spiral Spiral-Graph" spiralSpiralGraph
+    , makeExample "Rounded Rect" roundedRect
+
+    , makeExample "Thaw/Freeze" thawFreeze
+    , makeExample "Dictionaries" dictionaries
+    , makeExample "3 Boxes" threeBoxes
+
+    , makeExample "N Boxes Sli" nBoxes
+    , makeExample "N Boxes" groupOfBoxes
+
+    , makeExample "Rings" rings
+    , makeExample "Polygons" polygons
+    , makeExample "Stars" stars
+    , makeExample "Triangles" equiTri
+    , makeExample "Frank Lloyd Wright" flw1
+    , makeExample "Frank Lloyd Wright B" flw2
+    , makeExample "Bezier Curves" bezier
+    , makeExample "Fractal Tree" fractalTree
+    , makeExample "Stick Figures" stickFigures
+    , makeExample "Cult of Lambda" cultOfLambda
+    , makeExample "Matrix Transformations" matrices
+    , makeExample "Misc Shapes" miscShapes
+    , makeExample "Interface Buttons" interfaceButtons
+    , makeExample "Paths 1" paths1
+    , makeExample "Paths 2" paths2
+    , makeExample "Paths 3" paths3
+    , makeExample "Paths 4" paths4
+    , makeExample "Paths 5" paths5
+    , makeExample "Sample Rotations" rotTest
+    , makeExample "Grid Tile" gridTile
+    , makeExample "Zones" zones
+    , makeExample "Rectangle Trisection" rectangleTrisection
+    , makeExample "Battery" battery
+    , makeExample "Battery (Dynamic)" batteryDynamic
+    , makeExample "Mondrian Arch" mondrianArch
+    , makeExample "Ladder" ladder
+    , makeExample "Rails" rails
+    , makeExample "Target" target
+    , makeExample "Xs" xs
+    , makeExample "Conifer" conifer
+    , makeExample "Ferris Wheel 3" ferris3
+    , makeExample "Gear" gear
+    , makeExample "Koch Snowflake" kochSnowflake
+    , makeExample "Replace Terminals With Workstations" replaceTerminalsWithWorkstations
+    , makeExample "Balance Scale" balanceScale
+    , makeExample "Pencil Tip" pencilTip
+    , makeExample "Calendar Icon" calendarIcon
+    ]
+  )
+
+templateCategories =
+  [ generalCategory
+  , defaultIconCategory
+  , logoCategory
+  , flagCategory
+  , otherCategory
+  ]
 
 examples =
   [ makeExample "BLANK" blank

--- a/src/ExamplesTemplate.elm
+++ b/src/ExamplesTemplate.elm
@@ -1,4 +1,4 @@
-module ExamplesGenerated exposing (list)
+module ExamplesGenerated exposing (list, templateCategories)
 
 import Lang
 import LangParser2 as Parser
@@ -8,6 +8,8 @@ import Utils
 import PreludeGenerated as Prelude
 import LangSvg
 import DefaultIconTheme
+
+fst (a, _) = a
 
 makeExample name s =
   let thunk () =
@@ -145,6 +147,151 @@ LITTLE_TO_ELM balanceScale
 LITTLE_TO_ELM pencilTip
 LITTLE_TO_ELM calendarIcon
 
+generalCategory =
+  ( "General"
+  , [ makeExample "BLANK" blank
+    , makeExample "*Prelude*" Prelude.src
+    ]
+  )
+
+defaultIconCategory =
+  ( "Default Icons"
+  , [ makeExample "Icon: Cursor" DefaultIconTheme.cursor
+    , makeExample "Icon: Text" DefaultIconTheme.text
+    , makeExample "Icon: Line" DefaultIconTheme.line
+    , makeExample "Icon: Rect" DefaultIconTheme.rect
+    , makeExample "Icon: Ellipse" DefaultIconTheme.ellipse
+    , makeExample "Icon: Polygon" DefaultIconTheme.polygon
+    , makeExample "Icon: Path" DefaultIconTheme.path
+    ]
+  )
+
+logoCategory =
+  ( "Logos"
+  , List.sortBy fst
+      [ makeExample "SnS Logo (UIST)" sns_UIST
+      , makeExample "SnS Logo Revisited (UIST)" sns_revisited_UIST
+      , makeExample "Botanic Garden Logo (UIST)" botanic_UIST
+      , makeExample "Logo" logo
+      , makeExample "Botanic Garden Logo" botanic
+      , makeExample "Active Trans Logo" activeTrans2
+      , makeExample "SnS Logo Wheel" snsLogoWheel
+      , makeExample "Haskell.org Logo" haskell
+      , makeExample "Cover Logo" cover
+      , makeExample "POP-PL Logo" poppl
+      , makeExample "Floral Logo 1" floralLogo
+      , makeExample "Floral Logo 2" floralLogo2
+      , makeExample "Elm Logo" elmLogo
+      , makeExample "Logo 2" logo2
+      , makeExample "Logo Sizes" logoSizes
+      ]
+  )
+
+flagCategory =
+  ( "Flags"
+  , List.sortBy fst
+      [ makeExample "Chicago Flag" chicago
+      , makeExample "US-13 Flag" usFlag13
+      , makeExample "US-50 Flag" usFlag50
+      , makeExample "French Sudan Flag" frenchSudan
+      ]
+  )
+
+
+otherCategory =
+  ( "Other"
+  , [ makeExample "Coffee Mugs (UIST)" coffee_UIST
+
+    , makeExample "Wave Boxes" sineWaveOfBoxes
+    , makeExample "Wave Boxes Grid" sineWaveGrid
+
+    , makeExample "Basic Slides" basicSlides
+    , makeExample "Sailboat" sailBoat
+    , makeExample "Sliders" sliders
+    , makeExample "Buttons" buttons
+    , makeExample "Widgets" widgets
+    , makeExample "xySlider" xySlider
+    , makeExample "Offsets" offsets
+    , makeExample "Tile Pattern" boxGridTokenFilter
+    , makeExample "Color Picker" rgba
+    , makeExample "Ferris Wheel" ferris
+    , makeExample "Ferris Task Before" ferris2
+    , makeExample "Ferris Task After" ferris2target
+    , makeExample "Ferris Wheel Slideshow" ferrisWheelSlideshow
+    , makeExample "Survey Results" surveyResultsTriHist2
+    , makeExample "Hilbert Curve Animation" hilbertCurveAnimation
+    , makeExample "Bar Graph" barGraph
+    , makeExample "Pie Chart" pieChart1
+    , makeExample "Solar System" solarSystem
+    , makeExample "Clique" clique
+    , makeExample "Eye Icon" eyeIcon
+    , makeExample "Horror Films" horrorFilms0
+    , makeExample "Cycling Association" cyclingAssociation0
+    , makeExample "Lillicon P" lilliconP
+    , makeExample "Lillicon P, v2" lilliconP2
+    , makeExample "Keyboard" keyboard
+    , makeExample "Keyboard Task Before" keyboard2
+    , makeExample "Keyboard Task After" keyboard2target
+    , makeExample "Tessellation Task Before" tessellation
+    , makeExample "Tessellation Task After" tessellationTarget
+    , makeExample "Tessellation 2" tessellation2
+    , makeExample "Spiral Spiral-Graph" spiralSpiralGraph
+    , makeExample "Rounded Rect" roundedRect
+
+    , makeExample "Thaw/Freeze" thawFreeze
+    , makeExample "Dictionaries" dictionaries
+    , makeExample "3 Boxes" threeBoxes
+
+    , makeExample "N Boxes Sli" nBoxes
+    , makeExample "N Boxes" groupOfBoxes
+
+    , makeExample "Rings" rings
+    , makeExample "Polygons" polygons
+    , makeExample "Stars" stars
+    , makeExample "Triangles" equiTri
+    , makeExample "Frank Lloyd Wright" flw1
+    , makeExample "Frank Lloyd Wright B" flw2
+    , makeExample "Bezier Curves" bezier
+    , makeExample "Fractal Tree" fractalTree
+    , makeExample "Stick Figures" stickFigures
+    , makeExample "Cult of Lambda" cultOfLambda
+    , makeExample "Matrix Transformations" matrices
+    , makeExample "Misc Shapes" miscShapes
+    , makeExample "Interface Buttons" interfaceButtons
+    , makeExample "Paths 1" paths1
+    , makeExample "Paths 2" paths2
+    , makeExample "Paths 3" paths3
+    , makeExample "Paths 4" paths4
+    , makeExample "Paths 5" paths5
+    , makeExample "Sample Rotations" rotTest
+    , makeExample "Grid Tile" gridTile
+    , makeExample "Zones" zones
+    , makeExample "Rectangle Trisection" rectangleTrisection
+    , makeExample "Battery" battery
+    , makeExample "Battery (Dynamic)" batteryDynamic
+    , makeExample "Mondrian Arch" mondrianArch
+    , makeExample "Ladder" ladder
+    , makeExample "Rails" rails
+    , makeExample "Target" target
+    , makeExample "Xs" xs
+    , makeExample "Conifer" conifer
+    , makeExample "Ferris Wheel 3" ferris3
+    , makeExample "Gear" gear
+    , makeExample "Koch Snowflake" kochSnowflake
+    , makeExample "Replace Terminals With Workstations" replaceTerminalsWithWorkstations
+    , makeExample "Balance Scale" balanceScale
+    , makeExample "Pencil Tip" pencilTip
+    , makeExample "Calendar Icon" calendarIcon
+    ]
+  )
+
+templateCategories =
+  [ generalCategory
+  , defaultIconCategory
+  , logoCategory
+  , flagCategory
+  , otherCategory
+  ]
 
 examples =
   [ makeExample "BLANK" blank

--- a/src/InterfaceView3.elm
+++ b/src/InterfaceView3.elm
@@ -914,21 +914,40 @@ bigDialogBox = dialogBox "100" "85%" "85%"
 smallDialogBox = dialogBox "101" "35%" "35%"
 
 fileNewDialogBox model =
-  let viewTemplate (name, _) =
-        Html.div
-          [ Attr.style
-              [ ("font-family", "monospace")
-              , ("font-size", "1.2em")
-              , ("padding", "20px")
-              , ("border-bottom", "1px solid black")
+  let
+    viewTemplate (name, _) =
+      Html.div
+        [ Attr.style
+            [ ("font-family", "monospace")
+            , ("font-size", "1.2em")
+            , ("margin-bottom", "10px")
+            , ("padding", "10px 20px")
+            --, ("border-top", "1px solid black")
+            --, ("border-bottom", "1px solid black")
+            , ("background-color", "rgba(0, 0, 0, 0.1)")
+            ]
+        ]
+        [ htmlButton
+            name
+            (Controller.msgAskNew name model.needsSave)
+            Regular
+            False
+        ]
+    viewCategory (categoryName, templates) =
+      Html.div
+        []
+        ( [ Html.h1
+              [ Attr.style
+                [ ("padding", "10px 20px")
+                --, ("border-top", "2px solid black")
+                --, ("border-bottom", "2px solid black")
+                , ("background-color", "rgba(0, 0, 0, 0.2)")
+                ]
               ]
+              [ Html.text categoryName ]
           ]
-          [ htmlButton
-              name
-              (Controller.msgAskNew name model.needsSave)
-              Regular
-              False
-          ]
+          ++ List.map viewTemplate templates
+        )
   in
     bigDialogBox
       True
@@ -937,7 +956,7 @@ fileNewDialogBox model =
       []
       [Html.text "New..."]
       []
-      (List.map viewTemplate Examples.list)
+      (List.map viewCategory Examples.templateCategories)
 
 fileSaveAsDialogBox model =
   let saveAsInput =


### PR DESCRIPTION
Templates can now be grouped into categories in the new file dialog box.
To change these categories, edit `ExamplesTemplate.elm`, then recompile
the examples.

Note that the order of the categories and the templates within the
category is preserved, so if alphabetizing is desired, manual sorting
based on the first element (the name) of the `makeExample` pair is
needed. This can be done by calling `List.sortBy fst`.