### PR TITLE
Clean up Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ of the project clone.
 
 1. Install [Elm v0.18](http://elm-lang.org/)
 2. `cd SKETCH-N-SKETCH/src`
-3. `make clean`
+3. `make`
 4. Launch `SKETCH-N-SKETCH/build/out/index.html`
 
 Note: The parser has a performance issue that we have not yet addressed.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,33 +2,20 @@ ELMMAKE=elm-make
   # for locally-modified Elm compiler, create a symlink to something like:
   # /PATH/TO/elm-make/.stack-work/install/x86_64-osx/lts-3.22/7.10.2/bin/elm-make
 
-all: elm-stuff/packages
-	$(ELMMAKE) Main.elm --output ../build/out/sns.js
-	# sed -i '' 's/var Elm = {};/var Elm = {};\nElm["EvalUpdate"] = Elm["EvalUpdate"] || {};\nElm["EvalUpdate"].api = _user$$project$$EvalUpdate$$api;/g' ../build/out/sns.js
+out_from_Native :=aceCodeBox.js outputCanvas.js aceTooltips.js animationLoop.js fileHandler.js deucePopupPanelInfo.js \
+ dotGraph.js colorScheme.js syntaxHighlight.js focus.js keyBlocker.js solverServer.js
+
+out_from_ace-builds :=ace.js mode-little.js mode-elm.js theme-chrome.js
+
+all: prelude examples html
 
 html: elm-stuff/packages
 	$(ELMMAKE) Main.elm --output ../build/out/sns.js
-	cp Native/aceCodeBox.js ../build/out/
-	cp Native/outputCanvas.js ../build/out/
-	cp Native/aceTooltips.js ../build/out/
-	cp Native/animationLoop.js ../build/out/
-	cp Native/fileHandler.js ../build/out/
-	cp Native/deucePopupPanelInfo.js ../build/out/
-	cp Native/dotGraph.js ../build/out/
-	cp Native/colorScheme.js ../build/out/
-	cp Native/syntaxHighlight.js ../build/out/
-	cp Native/focus.js ../build/out/
-	cp Native/keyBlocker.js ../build/out/
-	cp Native/solverServer.js ../build/out/
-	cp ../ace-builds/src/ace.js ../build/out/
-	cp ../ace-builds/src/mode-little.js ../build/out/
-	cp ../ace-builds/src/mode-elm.js ../build/out/
-	cp ../ace-builds/src/theme-chrome.js ../build/out/
+	cd Native && cp $(out_from_Native) ../../build/out/
+	cd ../ace-builds/src && cp $(out_from_ace-builds) ../../build/out/
 	cp ../viz.js/viz.js ../build/out/
 	mkdir -p ../build/out/img
-	cp ../img/sketch-n-sketch-logo.png ../build/out/img/
-	cp ../img/light_logo.svg ../build/out/img/
-	cp ../img/*.png ../build/out/img/
+	cp ../img/* ../build/out/img/
 	# sed -i '' 's/var Elm = {};/var Elm = {};\nElm["EvalUpdate"] = Elm["EvalUpdate"] || {};\nElm["EvalUpdate"].api = _user$$project$$EvalUpdate$$api;/g' ../build/out/sns.js
 
 elm-stuff/packages:
@@ -43,9 +30,14 @@ elm-stuff/packages:
 	cd ../../../..
 
 remove_build_artifacts:
-	rm -r elm-stuff/build-artifacts/0.*/user; rm -r ../tests/elm-stuff/build-artifacts/0.*/user; true
+	rm -rf elm-stuff/build-artifacts/0.*/user
+	rm -rf ../tests/elm-stuff/build-artifacts/0.*/user
 
-clean: remove_build_artifacts prelude examples html
+# TODO there are some files in ../build/out that aren't in .gitignore, but if we could copy those into
+# ../build/out from somwhere else during an html build, then clean could just delete everything under
+# ../build/out
+clean: remove_build_artifacts
+	cd ../build/out && rm -rf sns.js $(out_from_Native) $(out_from_ace-builds) viz.js img/*
 
 prelude:
 	../scripts/expandTemplate.py Prelude


### PR DESCRIPTION
`make clean` now no longer builds, but it deletes more build output that
is sometimes useful to clean up in order to get a truly fresh build.
`make` now does what `make clean` used to do, which I think is more
intuitive. A TODO is to have all files that are in build/out be copied
from elsewhere - currently, some of those files are checked in to the
repo so `make clean` can't just do `rm -rf build/out`